### PR TITLE
fix: Discord 봇 중복 응답 제거 및 API 타임아웃 연장

### DIFF
--- a/ai-influencer/discord-bot/main.py
+++ b/ai-influencer/discord-bot/main.py
@@ -53,7 +53,7 @@ def get_gateway_client() -> httpx.AsyncClient:
         _gateway_client = httpx.AsyncClient(
             base_url=config.gateway_url,
             headers={"X-Internal-Secret": config.gateway_internal_secret},
-            timeout=15.0,
+            timeout=30.0,
         )
     return _gateway_client
 

--- a/ai-influencer/messenger-gateway/main.py
+++ b/ai-influencer/messenger-gateway/main.py
@@ -102,17 +102,6 @@ async def receive_message(_: AuthDep, body: IncomingMessageRequest) -> dict:
         logger.error("[discord] call_wf01_input failed job_id=%s: %s", body.job_id, e)
         await job_service.update_job(body.job_id, error_message=str(e))
 
-    try:
-        ack_text = (
-            f"✅ 요청이 접수되었습니다!\n"
-            f"Job ID: {body.job_id[:8]}...\n"
-            f"콘셉트: {body.concept_text[:50]}...\n\n"
-            "잠시 후 처리 결과를 알려드릴게요. ⏳"
-        )
-        await _discord_adapter.send_text_message(body.messenger_channel_id, ack_text)
-    except Exception as e:
-        logger.error("[discord] ack message failed job_id=%s: %s", body.job_id, e)
-
     return {"job_id": body.job_id, "status": "accepted"}
 
 
@@ -229,17 +218,6 @@ async def report_message(_: AuthDep, body: ReportMessageRequest) -> dict:
     except Exception as e:
         logger.error("[discord] call_wf06_report failed job_id=%s: %s", body.job_id, e)
         await job_service.update_job(body.job_id, error_message=str(e))
-
-    try:
-        ack_text = (
-            f"📊 보고서 생성 요청이 접수되었습니다!\n"
-            f"Job ID: {body.job_id[:8]}...\n"
-            f"프롬프트: {body.prompt[:50]}...\n\n"
-            "NotebookLM에서 보고서를 생성 중입니다. 최대 5분 소요될 수 있습니다. ⏳"
-        )
-        await _discord_adapter.send_text_message(body.messenger_channel_id, ack_text)
-    except Exception as e:
-        logger.error("[discord] ack report message failed job_id=%s: %s", body.job_id, e)
 
     return {"job_id": body.job_id, "status": "accepted"}
 


### PR DESCRIPTION
## 변경 사항
- **Discord Bot**: `discord-bot/main.py` 내부 Gateway API 호출 Timeout 시간을 15.0초에서 30.0초로 연장
- **Messenger Gateway**: `messenger-gateway/main.py` 디스코드 채널로 보내는 불필요한 중복 ACK 메시지 구문 제거

봇이 응답 지연 시 오류를 발생시키던 문제와 디스코드 채널에 중복으로 접수 메시지가 전송되던 이슈를 수정했습니다.