### PR TITLE
fix: Report Pipeline 개선 (웹훅 타임아웃 및 로깅 추가)

### DIFF
--- a/ai-influencer/messenger-gateway/services/n8n_service.py
+++ b/ai-influencer/messenger-gateway/services/n8n_service.py
@@ -99,5 +99,7 @@ async def call_wf06_report(
         "notebook_id": notebook_id,
         "character_id": character_id,
     }
-    await _post_with_retry(settings.n8n_wf06_webhook_url, payload)
+    client = get_http_client()
+    resp = await client.post(settings.n8n_wf06_webhook_url, json=payload, headers=_headers())
+    resp.raise_for_status()
     logger.info("[%s] call_wf06_report job_id=%s", messenger_source, job_id)

--- a/ai-influencer/n8n/workflows/WF-06_notebooklm_report.json
+++ b/ai-influencer/n8n/workflows/WF-06_notebooklm_report.json
@@ -5,7 +5,7 @@
       "parameters": {
         "httpMethod": "POST",
         "path": "wf-06-report",
-        "responseMode": "lastNode",
+        "responseMode": "onReceived",
         "options": {}
       },
       "id": "wf06-webhook",

--- a/ai-influencer/notebooklm-service/scripts/generate_report_cua.py
+++ b/ai-influencer/notebooklm-service/scripts/generate_report_cua.py
@@ -1,5 +1,6 @@
 import argparse
 import base64
+import logging
 import sys
 import time
 from pathlib import Path
@@ -7,6 +8,13 @@ from datetime import datetime
 
 from playwright.sync_api import sync_playwright
 from openai import OpenAI
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stdout,
+)
+logger = logging.getLogger("generate_report_cua")
 
 DATA_DIR = Path(__file__).parent.parent / "data"
 BROWSER_PROFILE_DIR = DATA_DIR / "browser_state" / "browser_profile"
@@ -30,10 +38,12 @@ def execute_action(page, action: dict):
 
 
 def generate_report(prompt: str, notebook_url: str, output_path: str, headless: bool = True) -> str:
+    logger.info("[CUA] 시작 prompt=%r url=%s headless=%s", prompt, notebook_url, headless)
     client = OpenAI()
     BROWSER_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
 
     with sync_playwright() as p:
+        logger.info("[CUA] Chromium 브라우저 시작 profile=%s", BROWSER_PROFILE_DIR)
         context = p.chromium.launch_persistent_context(
             user_data_dir=str(BROWSER_PROFILE_DIR),
             headless=headless,
@@ -45,7 +55,9 @@ def generate_report(prompt: str, notebook_url: str, output_path: str, headless: 
             viewport={"width": 1280, "height": 800},
         )
         page = context.new_page()
+        logger.info("[CUA] 노트북 URL 이동 중...")
         page.goto(notebook_url, wait_until="networkidle", timeout=60000)
+        logger.info("[CUA] 페이지 로드 완료: %s", page.title())
 
         task = (
             f"NotebookLM 스튜디오에서 보고서를 생성하라.\n"
@@ -57,6 +69,7 @@ def generate_report(prompt: str, notebook_url: str, output_path: str, headless: 
         messages = [{"role": "user", "content": task}]
 
         for step in range(30):
+            logger.info("[CUA] 스텝 %d/30 — 스크린샷 캡처 후 GPT-5.4 호출", step + 1)
             screenshot_b64 = base64.b64encode(page.screenshot()).decode()
             messages.append({
                 "role": "user",
@@ -90,16 +103,20 @@ def generate_report(prompt: str, notebook_url: str, output_path: str, headless: 
 
             for output in response.output:
                 if output.type == "computer_call":
+                    logger.info("[CUA] 액션 실행: %s", output.action)
                     execute_action(page, output.action)
                     assistant_msgs.append(output)
                 elif output.type == "text":
+                    logger.info("[CUA] 모델 텍스트 응답: %s", output.text[:200])
                     if "REPORT_DONE:" in output.text:
                         report_text = output.text.split("REPORT_DONE:", 1)[1].strip()
+                        logger.info("[CUA] REPORT_DONE 감지 (길이=%d chars)", len(report_text))
                     assistant_msgs.append(output)
 
             if report_text:
                 Path(output_path).parent.mkdir(parents=True, exist_ok=True)
                 Path(output_path).write_text(report_text, encoding="utf-8")
+                logger.info("[CUA] 보고서 저장 완료: %s", output_path)
                 context.close()
                 return output_path
 


### PR DESCRIPTION
## 변경 사항
- **Messenger Gateway**: `n8n_service.py` 내의 노트북 리포트 요청을 하는 웹훅 호출 방식 변경 (`_post_with_retry` -> `httpx.AsyncClient` 의 post 이용 및 `raise_for_status()`)
- **n8n Workflow**: `WF-06_notebooklm_report.json`에서 웹훅 노드의 `responseMode`를 `lastNode`에서 `onReceived`로 변경하여 불필요한 지연응답 방지
- **CUA Script**: `generate_report_cua.py` 스크립트 실행 과정 파악을 위한 로깅 추가

노트북 보고서 생성 파이프라인의 안정성을 도모하고, n8n 웹훅 요청 간의 타임아웃/응답 방식을 개선하기 위한 수정입니다.