### PR TITLE
fix: CUA 스크립트 모델명을 'computer-use-preview'로 수정

### DIFF
--- a/ai-influencer/notebooklm-service/scripts/generate_report_cua.py
+++ b/ai-influencer/notebooklm-service/scripts/generate_report_cua.py
@@ -96,7 +96,7 @@ def generate_report(prompt: str, notebook_url: str, output_path: str, headless: 
             logger.info("[CUA] 스텝 %d/30 — Responses API 호출", step + 1)
 
             response = client.responses.create(
-                model="gpt-5.4",
+                model="computer-use-preview",
                 tools=tools,
                 input=input_items,
                 truncation="auto",


### PR DESCRIPTION
## 변경 사항
- **NotebookLM Service**: `generate_report_cua.py` 스크립트 내 API 호출 모델명을 `gpt-5.4`에서 `computer-use-preview`로 수정

이전에 병합된 PR(#64) 이후 추가로 발견된 모델명 오타를 수정하기 위한 PR입니다.