### PR TITLE
fix: Add browser execution arguments for playwright headless mode

### DIFF
--- a/ai-influencer/notebooklm-service/scripts/setup_auth.py
+++ b/ai-influencer/notebooklm-service/scripts/setup_auth.py
@@ -21,6 +21,7 @@ def main():
         context = p.chromium.launch_persistent_context(
             user_data_dir=str(BROWSER_PROFILE_DIR),
             headless=False,
+            args=["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
         )
         page = context.new_page()
         page.goto("https://accounts.google.com")


### PR DESCRIPTION
Add browser execution arguments for playwright headless mode in `setup_auth.py` to fix memory and rendering issues during Chromium execution.