### PR TITLE
Fix: script_json update from jobs table

### DIFF
--- a/ai-influencer/n8n/workflows/WF-06_notebooklm_report.json
+++ b/ai-influencer/n8n/workflows/WF-06_notebooklm_report.json
@@ -102,7 +102,7 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "UPDATE jobs SET status='PUBLISHED', script_json='{{ JSON.stringify({script: $('Call NotebookLM Service').item.json.report_content}) }}'::jsonb, updated_at=NOW() WHERE id='{{ $('Extract Fields').item.json.job_id }}'",
+        "query": "UPDATE jobs SET status='PUBLISHED', updated_at=NOW() WHERE id='{{ $('Extract Fields').item.json.job_id }}'",
         "options": {}
       },
       "id": "wf06-pg-published",


### PR DESCRIPTION
Update the SQL executed by the workflow to stop writing NotebookLM report content into jobs.script_json. The query now only sets status='PUBLISHED' and updated_at for the job (using the job_id from 'Extract Fields'). This prevents the workflow from storing the serialized report payload in the jobs row; report content should be handled elsewhere.