### PR TITLE
Fix: Run report actions asynchronously and improve UX

### DIFF
--- a/ai-influencer/discord-bot/main.py
+++ b/ai-influencer/discord-bot/main.py
@@ -205,7 +205,7 @@ async def report_command(interaction: discord.Interaction, prompt: str) -> None:
             },
         )
         await interaction.followup.send(
-            f"📊 보고서 생성 요청이 접수되었습니다!\nJob ID: {job_id[:8]}...\n프롬프트: {prompt[:50]}...\n\nNotebookLM에서 보고서를 생성 중입니다. 최대 5분 소요될 수 있습니다. ⏳"
+            f"📊 요청 접수! 기존 보고서가 있으면 선택지가, 없으면 새 보고서 생성을 시작합니다. ⏳\nJob ID: `{job_id[:8]}`"
         )
     except Exception:
         await interaction.followup.send("보고서 요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")

--- a/ai-influencer/messenger-gateway/main.py
+++ b/ai-influencer/messenger-gateway/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import base64
 from contextlib import asynccontextmanager
@@ -208,8 +209,12 @@ async def confirm_action(_: AuthDep, body: ConfirmActionRequest) -> dict:
 async def report_message(_: AuthDep, body: ReportMessageRequest) -> dict:
     """봇 서비스가 report: 프리픽스 메시지를 포워딩한다."""
     await job_service.create_job(body)
+    # 즉시 반환 후 background에서 list-reports → 버튼 or WF-06
+    asyncio.create_task(_handle_report_message_bg(body))
+    return {"job_id": body.job_id, "status": "accepted"}
 
-    # 기존 보고서 목록 조회 시도 (notebooklm-service 직접 호출)
+
+async def _handle_report_message_bg(body: ReportMessageRequest) -> None:
     reports: list[str] = []
     try:
         resp = await _http_client.post(
@@ -226,22 +231,18 @@ async def report_message(_: AuthDep, body: ReportMessageRequest) -> dict:
         logger.warning("[report-message] list-reports 조회 실패 (WF-06 fallback): %s", e)
 
     if reports:
-        # 기존 보고서가 있으면 선택 버튼 제시
         try:
             await _discord_adapter.send_report_list(
                 channel_id=body.messenger_channel_id,
                 job_id=body.job_id,
                 reports=reports,
             )
+            return
         except Exception as e:
             logger.error("[report-message] send_report_list failed job_id=%s: %s", body.job_id, e)
-            # 전송 실패 시에도 WF-06 fallback
-            await _call_wf06(body)
-        return {"job_id": body.job_id, "status": "accepted", "report_list": True}
 
     # 기존 보고서 없거나 에러 → WF-06 직행
     await _call_wf06(body)
-    return {"job_id": body.job_id, "status": "accepted"}
 
 
 async def _call_wf06(body: ReportMessageRequest) -> None:
@@ -267,19 +268,31 @@ async def report_select(_: AuthDep, body: ReportSelectRequest) -> dict:
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
 
+    if body.action not in ("select", "new"):
+        raise HTTPException(status_code=400, detail=f"Unknown action: {body.action}")
+    if body.action == "select" and body.report_index is None:
+        raise HTTPException(status_code=400, detail="report_index is required for action=select")
+
+    # 즉시 반환 후 background에서 처리 (get-report는 최대 300s 소요)
+    asyncio.create_task(_handle_report_select_bg(body, job))
+    return {"job_id": body.job_id, "status": "accepted"}
+
+
+async def _handle_report_select_bg(body: ReportSelectRequest, job: dict) -> None:
     channel_id = job["messenger_channel_id"]
 
     if body.action == "select":
-        if body.report_index is None:
-            raise HTTPException(status_code=400, detail="report_index is required for action=select")
+        # 진행 중 안내 메시지
+        try:
+            await _discord_adapter.send_text_message(channel_id, "📄 보고서를 가져오는 중입니다... (10~30초 소요)")
+        except Exception:
+            pass
 
-        # notebooklm-service /get-report 호출
         try:
             resp = await _http_client.post(
                 f"{settings.notebooklm_service_url}/get-report",
                 json={
                     "job_id": body.job_id,
-                    "notebook_id": job.get("notebook_id") or None,
                     "report_index": body.report_index,
                 },
                 headers={"X-Internal-Secret": settings.gateway_internal_secret},
@@ -289,10 +302,14 @@ async def report_select(_: AuthDep, body: ReportSelectRequest) -> dict:
             data = resp.json()
         except Exception as e:
             logger.error("[report-select] get-report failed job_id=%s: %s", body.job_id, e)
-            raise HTTPException(status_code=500, detail=str(e))
+            await _discord_adapter.send_text_message(channel_id, f"❌ 보고서 가져오기 실패: {e}")
+            return
 
         if data.get("status") != "success":
-            raise HTTPException(status_code=500, detail=data.get("error", "get-report 실패"))
+            err = data.get("error", "get-report 실패")
+            logger.error("[report-select] get-report error job_id=%s: %s", body.job_id, err)
+            await _discord_adapter.send_text_message(channel_id, f"❌ 보고서 가져오기 실패: {err}")
+            return
 
         report_content = data["report_content"]
         file_bytes = base64.b64decode(data["file_content_b64"])
@@ -313,14 +330,17 @@ async def report_select(_: AuthDep, body: ReportSelectRequest) -> dict:
             )
         except Exception as e:
             logger.error("[report-select] send_file_message failed job_id=%s: %s", body.job_id, e)
-            raise HTTPException(status_code=500, detail=str(e))
+            return
 
         await job_service.transition_status(body.job_id, "PUBLISHED")
         logger.info("[report-select] action=select done job_id=%s index=%d", body.job_id, body.report_index)
-        return {"job_id": body.job_id, "action": "select"}
 
     elif body.action == "new":
-        # WF-06 트리거 (기존 흐름) — concept_text에 prompt가 저장됨
+        try:
+            await _discord_adapter.send_text_message(channel_id, "🆕 새 보고서를 생성합니다... (최대 5분 소요)")
+        except Exception:
+            pass
+
         report_msg = ReportMessageRequest(
             job_id=job["id"],
             messenger_source=job["messenger_source"],
@@ -332,9 +352,6 @@ async def report_select(_: AuthDep, body: ReportSelectRequest) -> dict:
         )
         await _call_wf06(report_msg)
         logger.info("[report-select] action=new job_id=%s → WF-06 triggered", body.job_id)
-        return {"job_id": body.job_id, "action": "new"}
-
-    raise HTTPException(status_code=400, detail=f"Unknown action: {body.action}")
 
 
 @app.post("/internal/send-report")


### PR DESCRIPTION
Make report handling non-blocking and improve user feedback.

- Discord bot: tweak followup message wording for report requests.
- messenger-gateway: import asyncio and return immediately from report endpoints by spawning background tasks.
  - report_message now creates _handle_report_message_bg to fetch existing reports and either send a report list or trigger WF-06, while returning {job_id, status: accepted} immediately.
  - report_select now validates action/select parameters, spawns _handle_report_select_bg to perform long-running get-report/get-file work, and returns accepted immediately. Background flow now sends progress/failure messages to the channel and handles errors without blocking the request.
- Added better error logging and safer send_text_message wrappers to avoid crashing the background flow.

These changes prevent HTTP timeouts for long NotebookLM operations (get-report can take up to 300s) and provide clearer UX by acknowledging requests right away.