### PR TITLE
Fix: Use rssUrl instead of playlistId for YouTube feeds

### DIFF
--- a/ai-influencer/n8n/workflows/WF-09-youtube-source.json
+++ b/ai-influencer/n8n/workflows/WF-09-youtube-source.json
@@ -15,7 +15,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// TOPIC_CHANNELS 파싱: 채널별 (channelId, topic) 쌍 목록으로 펼치기\n// 형식: \"채널이름/채널ID+채널이름/채널ID+...\"\n// 예: \"노마드코더/UCUpJs89fSBXNolQGOYKn0YQ+조코딩/UCQNE2JmbasNYbjGAcuBiRRg\"\nconst raw = $env.TOPIC_CHANNELS || '';\nif (!raw.trim()) return [{ json: { skip: true, reason: 'TOPIC_CHANNELS 미설정' } }];\n\nconst channels = [];\nfor (const ch of raw.split('+')) {\n  const slashIdx = ch.indexOf('/');\n  if (slashIdx < 0) continue;\n  const channelName = ch.slice(0, slashIdx).trim();\n  const channelId   = ch.slice(slashIdx + 1).trim();\n  if (channelName && channelId) channels.push({\n    channelId,\n    topic: channelName,\n    playlistId: 'UULF' + channelId.slice(2),\n  });\n}\n\nif (channels.length === 0) return [{ json: { skip: true, reason: '파싱된 채널 없음' } }];\nreturn channels.map(ch => ({ json: ch }));",
+        "jsCode": "// TOPIC_CHANNELS 파싱: 채널별 (channelId, topic) 쌍 목록으로 펼치기\n// 형식: \"채널이름/채널ID+채널이름/채널ID+...\"\n// 예: \"노마드코더/UCUpJs89fSBXNolQGOYKn0YQ+조코딩/UCQNE2JmbasNYbjGAcuBiRRg\"\nconst raw = $env.TOPIC_CHANNELS || '';\nif (!raw.trim()) return [{ json: { skip: true, reason: 'TOPIC_CHANNELS 미설정' } }];\n\nconst channels = [];\nfor (const ch of raw.split('+')) {\n  const slashIdx = ch.indexOf('/');\n  if (slashIdx < 0) continue;\n  const channelName = ch.slice(0, slashIdx).trim();\n  const channelId   = ch.slice(slashIdx + 1).trim();\n  if (channelName && channelId) channels.push({\n    channelId,\n    topic: channelName,\n    rssUrl: 'https://www.youtube.com/feeds/videos.xml?playlist_id=UULF' + channelId.slice(2),\n  });\n}\n\nif (channels.length === 0) return [{ json: { skip: true, reason: '파싱된 채널 없음' } }];\nreturn channels.map(ch => ({ json: ch }));",
         "options": {}
       },
       "id": "wf09-parse-channels",
@@ -26,7 +26,7 @@
     },
     {
       "parameters": {
-        "url": "={{ 'https://www.youtube.com/feeds/videos.xml?playlist_id=' + $json.playlistId }}",
+        "url": "={{ $json.rssUrl }}",
         "method": "GET",
         "options": {
           "response": { "response": { "responseFormat": "text" } }


### PR DESCRIPTION
Change parser to build an rssUrl for each channel (https://www.youtube.com/feeds/videos.xml?playlist_id=UULF + channelId.slice(2)) instead of storing playlistId, and update the HTTP GET node to use $json.rssUrl. This ensures the workflow fetches the channel RSS feed directly.