### PR TITLE
Update: Make condition case-sensitive and bump node version

### DIFF
--- a/ai-influencer/n8n/workflows/WF-10-daily-notebook.json
+++ b/ai-influencer/n8n/workflows/WF-10-daily-notebook.json
@@ -27,6 +27,7 @@
     {
       "parameters": {
         "conditions": {
+          "options": { "caseSensitive": true },
           "conditions": [
             {
               "id": "skip-check",
@@ -65,7 +66,7 @@
       "id": "wf10-create-notebook",
       "name": "노트북 생성",
       "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4,
+      "typeVersion": 4.2,
       "position": [840, 220]
     },
     {


### PR DESCRIPTION
Enable case-sensitive matching by adding options.caseSensitive: true to the conditions in WF-10-daily-notebook.json, and update the wf10-create-notebook HTTP request node's typeVersion from 4 to 4.2. This ensures condition checks use case-sensitive comparison and aligns the node with the newer n8n node version.