### PR TITLE
Fix: Strip URL query and normalize Ctrl key

### DIFF
--- a/ai-influencer/notebooklm-service/main.py
+++ b/ai-influencer/notebooklm-service/main.py
@@ -138,15 +138,18 @@ def verify_secret(x_internal_secret: Optional[str] = None) -> None:
 # ─────────────────────────────────────────
 
 def _get_notebook_url(channel_id: str) -> Optional[str]:
-    """channel_id → notebook_url 직접 조회."""
+    """channel_id → notebook_url 직접 조회. 쿼리 파라미터는 제거해서 반환."""
     try:
         if not LIBRARY_JSON.exists():
             return None
         lib = json.loads(LIBRARY_JSON.read_text())
         ch = lib.get("channels", {}).get(channel_id)
         if ch and ch.get("notebook_url"):
-            logger.info("[resolve] channel_id=%s → %s", channel_id, ch["notebook_url"])
-            return ch["notebook_url"]
+            from urllib.parse import urlparse, urlunparse
+            parsed = urlparse(ch["notebook_url"])
+            clean_url = urlunparse(parsed._replace(query="", fragment=""))
+            logger.info("[resolve] channel_id=%s → %s", channel_id, clean_url)
+            return clean_url
         logger.warning("[resolve] channel_id=%r 에 해당하는 노트북 없음", channel_id)
     except Exception as e:
         logger.warning("library.json 읽기 실패: %s", e)

--- a/ai-influencer/notebooklm-service/scripts/generate_report_cua.py
+++ b/ai-influencer/notebooklm-service/scripts/generate_report_cua.py
@@ -201,7 +201,11 @@ def execute_action(page, action: dict) -> bool:
         page.keyboard.type(action["text"])
         time.sleep(0.3)
     elif t == "key":
-        page.keyboard.press(action["key"])
+        key = action["key"].replace("Ctrl+", "Control+").replace("Ctrl", "Control")
+        try:
+            page.keyboard.press(key)
+        except Exception as e:
+            logger.warning("[CUA] key press 실패 (무시): key=%r error=%s", key, e)
         time.sleep(0.5)
     elif t == "scroll":
         page.mouse.move(action.get("x", 640), action.get("y", 400))


### PR DESCRIPTION
Remove query and fragment components when resolving channel notebook URLs to return a clean URL (uses urllib.parse to rebuild URL without query/fragment). Normalize keyboard key names in the CU A script by converting "Ctrl" to Playwright's "Control" and add a try/except with a warning log around page.keyboard.press to ignore individual key press failures. These changes prevent leaking query params from library.json and make automated key presses more robust.