### PR TITLE
Update: Add CUA fallback and channel_name support

### DIFF
--- a/ai-influencer/n8n/workflows/WF-09-youtube-source.json
+++ b/ai-influencer/n8n/workflows/WF-09-youtube-source.json
@@ -61,7 +61,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// RSS XML 파싱: 최근 1.5시간 이내 업로드 영상만 추출\nconst xml = $input.item.json.data || '';\nconst channelId = $input.item.json.channelId || '';\nconst topic = $input.item.json.topic || '';\n\nconst entries = [];\nconst entryRegex = /<entry>([\\s\\S]*?)<\\/entry>/g;\nlet match;\n\nwhile ((match = entryRegex.exec(xml)) !== null) {\n  const block = match[1];\n  const videoId = (block.match(/<yt:videoId>([^<]+)<\\/yt:videoId>/) || [])[1];\n  const title = (block.match(/<title>([^<]+)<\\/title>/) || [])[1] || '';\n  const published = (block.match(/<published>([^<]+)<\\/published>/) || [])[1] || '';\n\n  if (!videoId) continue;\n\n  const publishedMs = new Date(published).getTime();\n  const cutoffMs = Date.now() - 90 * 60 * 1000; // 1.5시간 이내\n\n  if (publishedMs >= cutoffMs) {\n    entries.push({\n      videoUrl: `https://www.youtube.com/watch?v=${videoId}`,\n      title: title.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>'),\n      publishedAt: published,\n      channelId,\n      topic,\n    });\n  }\n}\n\nif (entries.length === 0) {\n  return [{ json: { skip: true, channelId, topic, reason: '새 영상 없음' } }];\n}\n\nreturn entries.map(e => ({ json: e }));",
+        "jsCode": "// RSS XML 파싱: 최근 1.5시간 이내 업로드 영상만 추출\nconst xml = $input.item.json.data || '';\n// HTTP 노드가 응답 body만 출력하므로 channelId/topic은 상위 노드에서 직접 참조\nconst channelId = $('채널 있는 경우만').item.json.channelId || '';\nconst topic = $('채널 있는 경우만').item.json.topic || '';\n\nconst entries = [];\nconst entryRegex = /<entry>([\\s\\S]*?)<\\/entry>/g;\nlet match;\n\nwhile ((match = entryRegex.exec(xml)) !== null) {\n  const block = match[1];\n  const videoId = (block.match(/<yt:videoId>([^<]+)<\\/yt:videoId>/) || [])[1];\n  const title = (block.match(/<title>([^<]+)<\\/title>/) || [])[1] || '';\n  const published = (block.match(/<published>([^<]+)<\\/published>/) || [])[1] || '';\n\n  if (!videoId) continue;\n\n  const publishedMs = new Date(published).getTime();\n  const cutoffMs = Date.now() - 90 * 60 * 1000; // 1.5시간 이내\n\n  if (publishedMs >= cutoffMs) {\n    entries.push({\n      videoUrl: `https://www.youtube.com/watch?v=${videoId}`,\n      title: title.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>'),\n      publishedAt: published,\n      channelId,\n      topic,\n    });\n  }\n}\n\nif (entries.length === 0) {\n  return [{ json: { skip: true, channelId, topic, reason: '새 영상 없음' } }];\n}\n\nreturn entries.map(e => ({ json: e }));",
         "options": {}
       },
       "id": "wf09-parse-rss",
@@ -104,7 +104,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ source_url: $json.videoUrl, source_title: $json.title, channel_id: $json.channelId, max_sources: $env.NOTEBOOKLM_MAX_SOURCES ? parseInt($env.NOTEBOOKLM_MAX_SOURCES) : 20 }) }}",
+        "jsonBody": "={{ JSON.stringify({ source_url: $json.videoUrl, source_title: $json.title, channel_id: $json.channelId, channel_name: $json.topic, max_sources: $env.NOTEBOOKLM_MAX_SOURCES ? parseInt($env.NOTEBOOKLM_MAX_SOURCES) : 20 }) }}",
         "options": {
           "timeout": 360000
         }

--- a/ai-influencer/notebooklm-service/main.py
+++ b/ai-influencer/notebooklm-service/main.py
@@ -92,6 +92,7 @@ class AddSourceRequest(BaseModel):
     notebook_id: Optional[str] = None
     notebook_url: Optional[str] = None
     channel_id: str = ""              # YouTube 채널 ID로 노트북 자동 조회
+    channel_name: str = ""            # CUA 폴백용 채널 표시 이름
     max_sources: int = 20             # 슬라이딩 윈도우 한도
 
 
@@ -407,15 +408,87 @@ async def get_report_endpoint(
     return response
 
 
+def _save_notebook_url_to_library(channel_id: str, channel_name: str, notebook_url: str) -> None:
+    """library.json의 channels[channel_id]에 notebook_url + name을 저장 (history는 건드리지 않음)."""
+    try:
+        lib: dict = {}
+        if LIBRARY_JSON.exists():
+            lib = json.loads(LIBRARY_JSON.read_text(encoding="utf-8"))
+        ch = lib.setdefault("channels", {}).setdefault(channel_id, {})
+        ch["notebook_url"] = notebook_url
+        if channel_name:
+            ch["name"] = channel_name
+        LIBRARY_JSON.parent.mkdir(parents=True, exist_ok=True)
+        LIBRARY_JSON.write_text(json.dumps(lib, ensure_ascii=False, indent=2), encoding="utf-8")
+        logger.info("[library] CUA 폴백 저장: channel_id=%s → %s", channel_id, notebook_url)
+    except Exception as e:
+        logger.warning("[library] 저장 실패: %s", e)
+
+
+def _get_notebook_url_via_cua(channel_name: str, channel_id: str) -> Optional[str]:
+    """manage_sources_cua.py --mode find로 NotebookLM 홈에서 노트북 URL을 찾는다."""
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
+        output_path = tmp.name
+
+    cmd = [
+        "python3",
+        str(SCRIPTS_DIR / "manage_sources_cua.py"),
+        "--mode", "find",
+        "--channel-name", channel_name,
+        "--output", output_path,
+        "--headless",
+    ]
+    logger.info("[cua-fallback] FIND_NB 시작: channel_name=%r", channel_name)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    except subprocess.TimeoutExpired:
+        logger.error("[cua-fallback] FIND_NB timeout (180s)")
+        return None
+    except Exception as e:
+        logger.error("[cua-fallback] FIND_NB error: %s", e)
+        return None
+
+    for line in (result.stdout or "").strip().splitlines():
+        logger.info("[script] %s", line)
+    for line in (result.stderr or "").strip().splitlines():
+        logger.warning("[script:err] %s", line)
+
+    try:
+        data = json.loads(Path(output_path).read_text(encoding="utf-8"))
+        url = data.get("notebook_url", "")
+        if url:
+            _save_notebook_url_to_library(channel_id, channel_name, url)
+        return url or None
+    except Exception as e:
+        logger.warning("[cua-fallback] 결과 파싱 실패: %s", e)
+        return None
+    finally:
+        Path(output_path).unlink(missing_ok=True)
+
+
 def _run_check_and_add_source(
     source_url: str,
     source_title: str,
     notebook_url: str,
     max_sources: int,
+    channel_id: str = "",
+    channel_name: str = "",
 ) -> AddSourceResponse:
     """소스 추가 + 슬라이딩 윈도우 정리를 subprocess로 실행."""
     scripts_dir = SCRIPTS_DIR
     manage_script = scripts_dir / "manage_sources_cua.py"
+
+    # Step 0: notebook_url 미결정 시 CUA 폴백
+    if not notebook_url:
+        if not channel_name:
+            return AddSourceResponse(status="error", error="notebook_url도 channel_name도 없음")
+        notebook_url = _get_notebook_url_via_cua(channel_name, channel_id) or ""
+        if not notebook_url:
+            return AddSourceResponse(
+                status="error",
+                error=f"CUA fallback 실패: channel_name={channel_name!r}",
+            )
 
     # Step 1: 중복 확인 (sources_log.json 직접 읽기)
     sources_log_path = DATA_DIR / "sources_log.json"
@@ -557,9 +630,7 @@ async def check_and_add_source(
 
     notebook_url = body.notebook_url or (
         _get_notebook_url(body.channel_id) if body.channel_id else None
-    )
-    if not notebook_url:
-        return AddSourceResponse(status="error", error="notebook_url을 결정할 수 없습니다.")
+    ) or ""
 
     import asyncio
     loop = asyncio.get_event_loop()
@@ -570,6 +641,8 @@ async def check_and_add_source(
         body.source_title,
         notebook_url,
         body.max_sources,
+        body.channel_id,
+        body.channel_name,
     )
     return response
 

--- a/ai-influencer/notebooklm-service/scripts/create_notebook_cua.py
+++ b/ai-influencer/notebooklm-service/scripts/create_notebook_cua.py
@@ -86,6 +86,29 @@ def _register_notebook(
 # CUA 노트북 생성
 # ─────────────────────────────────────────
 
+def rename_notebook(page, client, notebook_name: str) -> bool:
+    """CUA로 현재 열린 노트북 제목을 notebook_name으로 변경."""
+    TASK = (
+        "Task: Rename this NotebookLM notebook.\n"
+        f"Target name: '{notebook_name}'\n"
+        "Steps:\n"
+        "1. Find the notebook title at the top of the page "
+        "(currently 'Untitled notebook' or similar).\n"
+        "2. Click on the title text to make it editable.\n"
+        "3. Select all existing text (Ctrl+A) and delete it.\n"
+        f"4. Type the new name: {notebook_name}\n"
+        "5. Press Enter to confirm.\n"
+        f'Output {{"action": "done"}} when the new title is visible.\n'
+        "Do NOT navigate away from this page."
+    )
+    success = _run_cua_loop(page, client, TASK, max_steps=15, phase="RENAME_NB")
+    if success:
+        logger.info("[rename_notebook] 성공: %r", notebook_name)
+    else:
+        logger.warning("[rename_notebook] 실패 (15 스텝 초과) — 이름 미설정, URL은 유효")
+    return success
+
+
 def create_notebook(page, client, notebook_name: str) -> str:
     """CUA로 NotebookLM 홈에서 새 노트북을 생성하고 URL을 반환."""
     logger.info("[create_notebook] 홈 이동: %s", NOTEBOOKLM_HOME)
@@ -154,6 +177,8 @@ def main():
         page = context.new_page()
 
         notebook_url = create_notebook(page, client, args.name)
+        # 이름 변경 (실패해도 notebook_url은 유효하므로 계속 진행)
+        rename_notebook(page, client, args.name)
         context.close()
 
     _register_notebook(

--- a/ai-influencer/notebooklm-service/scripts/manage_sources_cua.py
+++ b/ai-influencer/notebooklm-service/scripts/manage_sources_cua.py
@@ -34,6 +34,7 @@ logger = logging.getLogger("manage_sources_cua")
 
 DATA_DIR = Path(__file__).parent.parent / "data"
 SOURCES_LOG_PATH = DATA_DIR / "sources_log.json"
+NOTEBOOKLM_HOME = "https://notebooklm.google.com"
 
 
 # ─────────────────────────────────────────
@@ -195,20 +196,61 @@ def list_sources_from_page(page, notebook_url: str) -> list[str]:
     return sources
 
 
+def find_notebook_url_by_name_cua(page, client, channel_name: str) -> str:
+    """NotebookLM 홈에서 channel_name으로 노트북을 찾아 URL 반환. 실패 시 '' 반환."""
+    page.goto(NOTEBOOKLM_HOME, wait_until="domcontentloaded", timeout=90000)
+    try:
+        page.wait_for_load_state("networkidle", timeout=30000)
+    except Exception:
+        pass
+    _ensure_logged_in(page)
+    time.sleep(2)
+
+    TASK = (
+        "Task: Find and open a specific notebook on the NotebookLM home page.\n"
+        f"Notebook to find: '{channel_name}'\n"
+        "Steps:\n"
+        "1. You are on the NotebookLM home page showing a grid of existing notebooks.\n"
+        f"2. Find a notebook card whose title contains '{channel_name}'.\n"
+        "   If multiple match, click the most recent one (highest date).\n"
+        "3. Click that notebook card to open it.\n"
+        "4. Wait for the URL to change to /notebook/...\n"
+        f'Output {{"action": "done"}} when the notebook is open.\n'
+        "If no matching notebook is found after scrolling, output done anyway."
+    )
+    success = _run_cua_loop(page, client, TASK, max_steps=15, phase="FIND_NB")
+    if not success:
+        logger.warning("[find_notebook] CUA 실패: channel_name=%r", channel_name)
+        return ""
+
+    time.sleep(2)
+    url = page.url
+    if "notebooklm.google.com/notebook/" not in url:
+        logger.warning("[find_notebook] 노트북 URL 획득 실패: %s", url)
+        return ""
+
+    logger.info("[find_notebook] 발견: %r → %s", channel_name, url)
+    return url
+
+
 # ─────────────────────────────────────────
 # 진입점
 # ─────────────────────────────────────────
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mode", required=True, choices=["list", "add", "delete", "cleanup"])
-    parser.add_argument("--notebook-url", required=True)
+    parser.add_argument("--mode", required=True, choices=["list", "add", "delete", "cleanup", "find"])
+    parser.add_argument("--notebook-url", default="")
+    parser.add_argument("--channel-name", default="")
     parser.add_argument("--output", default="")
     parser.add_argument("--source-url", default="")
     parser.add_argument("--source-title", default="")
     parser.add_argument("--max-sources", type=int, default=20)
     parser.add_argument("--headless", action="store_true")
     args = parser.parse_args()
+
+    if args.mode != "find" and not args.notebook_url:
+        parser.error("--notebook-url is required for this mode")
 
     BROWSER_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
     client = OpenAI()
@@ -226,7 +268,24 @@ def main():
         )
         page = context.new_page()
 
-        if args.mode == "list":
+        if args.mode == "find":
+            if not args.channel_name:
+                parser.error("--channel-name is required for --mode find")
+            notebook_url = find_notebook_url_by_name_cua(page, client, args.channel_name)
+            found = bool(notebook_url)
+            result = {"notebook_url": notebook_url, "found": found}
+            if args.output:
+                Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+                Path(args.output).write_text(
+                    json.dumps(result, ensure_ascii=False), encoding="utf-8"
+                )
+            print(json.dumps(result, ensure_ascii=False))
+            context.close()
+            if not found:
+                sys.exit(1)
+            return
+
+        elif args.mode == "list":
             sources = list_sources_from_page(page, args.notebook_url)
             result = {"sources": sources, "count": len(sources)}
             if args.output:


### PR DESCRIPTION
Allow adding sources by channel display name when notebook URL is unavailable. Updates:

- n8n workflow: include channel_name in the HTTP JSON body and update RSS parser comment to read channel info from upstream node.
- notebooklm-service/main.py: add channel_name to request model; implement _save_notebook_url_to_library and _get_notebook_url_via_cua to run manage_sources_cua.py to find a notebook by channel name; integrate CUA fallback into the add-source flow and pass channel_id/channel_name through the call chain.
- scripts/create_notebook_cua.py: add rename_notebook to update notebook title via CUA and call it after creation (non-fatal on failure).
- scripts/manage_sources_cua.py: add NOTEBOOKLM_HOME, implement find_notebook_url_by_name_cua to search NotebookLM home by channel name, add "find" mode and --channel-name CLI arg, and adjust argument validation.

This enables using a channel display name as a fallback to locate and cache the NotebookLM notebook URL, improving robustness when notebook_url is not provided.