### PR TITLE
Fix: use requestAnimationFrame in scrollToBottom for proper DOM layout

### DIFF
--- a/backend/templates/frontend/chat.html
+++ b/backend/templates/frontend/chat.html
@@ -1401,8 +1401,11 @@ function scrollToBottom() {
   if (!container) return;
   if (userScrolledUp) return;
   programmaticScroll = true;
-  container.scrollTop = container.scrollHeight;
-  setTimeout(() => { programmaticScroll = false; }, 150);
+  // Use requestAnimationFrame to ensure DOM has laid out new content
+  requestAnimationFrame(() => {
+    container.scrollTop = container.scrollHeight;
+    setTimeout(() => { programmaticScroll = false; }, 200);
+  });
 }
 
 function showTyping() {


### PR DESCRIPTION
Synchronous scrollHeight read was returning stale value before browser rendered new content. rAF ensures layout is complete before scrolling.