### PR TITLE
feat: 관리자 페이지 추가 및 로그아웃 기능 구현

### DIFF
--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -1,10 +1,13 @@
 from django.shortcuts import render, redirect
-from django.contrib.auth import login, logout, authenticate
+from django.contrib.auth import login, logout, authenticate, get_user_model
 from django.contrib.auth.models import User
+from django.contrib.admin.views.decorators import staff_member_required
 from django.http import JsonResponse
+from django.utils import timezone
 from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.http import require_POST
 from rest_framework import viewsets, permissions
-from .models import Message, ChatMemory
+from .models import Message, ChatMemory, HariKnowledge, GeneratedContent, VisitLog
 from .serializers import MessageSerializer, ChatMemorySerializer
 
 
@@ -103,3 +106,63 @@ def health_check(request):
         "database_error": db_error,
         "allowed_hosts": settings.ALLOWED_HOSTS,
     })
+
+
+# ── ADMIN PANEL ────────────────────────────────────────────────────────────────
+
+@staff_member_required(login_url='/')
+def admin_dashboard(request):
+    AuthUser = get_user_model()
+    today = timezone.now().date()
+    active_tab = request.GET.get('tab', 'dashboard')
+    search_user = request.GET.get('search_user', '')
+
+    users_qs = AuthUser.objects.order_by('-date_joined')
+    if search_user:
+        users_qs = users_qs.filter(username__icontains=search_user)
+
+    context = {
+        'active_tab': active_tab,
+        'search_user': search_user,
+        # stats
+        'total_users': AuthUser.objects.count(),
+        'today_visits': VisitLog.objects.filter(visit_time__date=today).count(),
+        'total_messages': Message.objects.count(),
+        'published_contents': GeneratedContent.objects.filter(is_published=True).count(),
+        'total_contents': GeneratedContent.objects.count(),
+        'total_knowledge': HariKnowledge.objects.count(),
+        'total_memories': ChatMemory.objects.count(),
+        # tables
+        'users': users_qs[:50],
+        'recent_users': AuthUser.objects.order_by('-date_joined')[:8],
+        'contents': GeneratedContent.objects.order_by('-created_at')[:50],
+        'hari_knowledge': HariKnowledge.objects.order_by('-updated_at'),
+        'recent_messages': Message.objects.select_related('user').order_by('-created_at')[:8],
+        'all_messages': Message.objects.select_related('user').order_by('-created_at')[:100],
+        'chat_memories': ChatMemory.objects.select_related('user').order_by('-ended_at')[:50],
+    }
+    return render(request, 'frontend/admin.html', context)
+
+
+@staff_member_required(login_url='/')
+@require_POST
+def admin_toggle_content(request, content_id):
+    try:
+        content = GeneratedContent.objects.get(content_id=content_id)
+        content.is_published = not content.is_published
+        content.save()
+        return JsonResponse({'ok': True, 'is_published': content.is_published})
+    except GeneratedContent.DoesNotExist:
+        return JsonResponse({'ok': False}, status=404)
+
+
+@staff_member_required(login_url='/')
+@require_POST
+def admin_toggle_knowledge(request, persona_id):
+    try:
+        k = HariKnowledge.objects.get(persona_id=persona_id)
+        k.is_active = not k.is_active
+        k.save()
+        return JsonResponse({'ok': True, 'is_active': k.is_active})
+    except HariKnowledge.DoesNotExist:
+        return JsonResponse({'ok': False}, status=404)

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -18,7 +18,7 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
-from chat.views import health_check, homepage, fanpage, frontend_chat
+from chat.views import health_check, homepage, fanpage, frontend_chat, admin_dashboard, admin_toggle_content, admin_toggle_knowledge
 
 urlpatterns = [
     path('', homepage, name='home'),
@@ -27,6 +27,9 @@ urlpatterns = [
     path('hari-chat/', frontend_chat, name='frontend_chat'),
     path('health/', health_check, name='health_check'),
     path('admin/', admin.site.urls),
+    path('admin-panel/', admin_dashboard, name='admin_panel'),
+    path('admin-panel/content/<int:content_id>/toggle/', admin_toggle_content, name='admin_toggle_content'),
+    path('admin-panel/knowledge/<int:persona_id>/toggle/', admin_toggle_knowledge, name='admin_toggle_knowledge'),
     path('accounts/', include('allauth.urls')),
     path('api/auth/', include('dj_rest_auth.urls')),
     path('api/auth/registration/', include('dj_rest_auth.registration.urls')),

--- a/backend/templates/frontend/admin.html
+++ b/backend/templates/frontend/admin.html
@@ -1,0 +1,849 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hari Admin</title>
+  <link rel="icon" type="image/png" href="{% static 'images/hari_favicon.png' %}">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/NeoDunggeunmo.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_eight@1.0/DOSSaemmul.css">
+  <style>
+  *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+  :root {
+    --bg:        #ffffff;
+    --ink:       #2a2420;
+    --acc:       #ff7b8a;
+    --acc2:      #ffd166;
+    --acc3:      #06d6a0;
+    --dim:       #9e9490;
+    --bdr:       rgba(255,123,138,0.12);
+    --bdr2:      rgba(255,123,138,0.22);
+    --surface:   #f7f5f4;
+    --sidebar-w: 220px;
+    --topbar-h:  56px;
+    --f-pixel:   'DOSSaemmul', sans-serif;
+    --f-neo:     'NeoDunggeunmo', sans-serif;
+  }
+  body {
+    background: var(--surface);
+    color: var(--ink);
+    font-family: 'Segoe UI', system-ui, sans-serif;
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+  ::-webkit-scrollbar { width: 2px; height: 2px; }
+  ::-webkit-scrollbar-thumb { background: var(--acc); }
+
+  /* ── SIDEBAR ─────────────────────────────── */
+  #sidebar {
+    position: fixed;
+    top: 0; left: 0; bottom: 0;
+    width: var(--sidebar-w);
+    background: var(--ink);
+    display: flex;
+    flex-direction: column;
+    z-index: 100;
+    overflow-y: auto;
+  }
+  .sidebar-header {
+    padding: 1.4rem 1.2rem 1rem;
+    border-bottom: 0.5px solid rgba(255,123,138,0.18);
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+  }
+  .sidebar-header img { height: 34px; width: auto; }
+  .sidebar-brand {
+    color: #fff5f6;
+    font-family: var(--f-pixel);
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    line-height: 1.4;
+  }
+  .sidebar-brand em {
+    display: block;
+    font-style: normal;
+    color: var(--acc);
+    font-size: 0.55rem;
+    letter-spacing: 0.3em;
+    margin-top: 1px;
+  }
+  .sidebar-nav {
+    flex: 1;
+    padding: 0.8rem 0;
+    list-style: none;
+  }
+  .sidebar-section-label {
+    padding: 0.9rem 1.2rem 0.3rem;
+    font-family: var(--f-pixel);
+    font-size: 0.5rem;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: rgba(255,245,246,0.25);
+  }
+  .sidebar-nav a {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.52rem 1.2rem;
+    color: rgba(255,245,246,0.45);
+    text-decoration: none;
+    font-size: 0.8rem;
+    letter-spacing: 0.02em;
+    transition: color 0.2s, background 0.2s;
+    border-left: 2px solid transparent;
+  }
+  .sidebar-nav a:hover { color: rgba(255,245,246,0.85); background: rgba(255,123,138,0.07); }
+  .sidebar-nav a.active { color: var(--acc); border-left-color: var(--acc); background: rgba(255,123,138,0.12); }
+  .nav-icon { font-size: 0.85rem; width: 18px; text-align: center; flex-shrink: 0; }
+  .sidebar-footer {
+    padding: 1rem 1.2rem;
+    border-top: 0.5px solid rgba(255,123,138,0.18);
+  }
+  .sidebar-footer a {
+    color: rgba(255,245,246,0.3);
+    text-decoration: none;
+    font-size: 0.72rem;
+    transition: color 0.2s;
+  }
+  .sidebar-footer a:hover { color: var(--acc); }
+
+  /* ── TOPBAR ──────────────────────────────── */
+  #topbar {
+    position: fixed;
+    top: 0; left: var(--sidebar-w); right: 0;
+    height: var(--topbar-h);
+    background: var(--bg);
+    border-bottom: 0.5px solid var(--bdr);
+    display: flex;
+    align-items: center;
+    padding: 0 1.8rem;
+    z-index: 90;
+    gap: 1rem;
+  }
+  .topbar-title {
+    font-family: var(--f-pixel);
+    font-size: 0.68rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--ink);
+    flex: 1;
+  }
+  .topbar-user {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.75rem;
+    color: var(--dim);
+  }
+  .topbar-badge {
+    background: var(--acc);
+    color: #fff;
+    font-family: var(--f-pixel);
+    font-size: 0.55rem;
+    padding: 2px 8px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  /* ── MAIN ────────────────────────────────── */
+  #main {
+    margin-left: var(--sidebar-w);
+    padding-top: var(--topbar-h);
+    min-height: 100vh;
+  }
+  .content-area { padding: 2rem 2rem; max-width: 1200px; }
+
+  /* ── SECTION TITLE ───────────────────────── */
+  .section-title {
+    font-family: var(--f-pixel);
+    font-size: 0.62rem;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--dim);
+    margin-bottom: 1.2rem;
+    padding-bottom: 0.6rem;
+    border-bottom: 0.5px solid var(--bdr);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .section-title::before {
+    content: '';
+    display: inline-block;
+    width: 5px; height: 5px;
+    background: var(--acc);
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  /* ── STAT CARDS ──────────────────────────── */
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(155px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  .stat-card {
+    background: var(--bg);
+    border: 0.5px solid var(--bdr);
+    padding: 1.3rem 1.2rem;
+    position: relative;
+    overflow: hidden;
+    transition: border-color 0.2s, box-shadow 0.2s;
+  }
+  .stat-card::after {
+    content: '';
+    position: absolute;
+    bottom: 0; left: 0; right: 0;
+    height: 2px;
+    background: var(--acc);
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+  .stat-card:hover { border-color: var(--bdr2); box-shadow: 0 2px 16px rgba(255,123,138,0.07); }
+  .stat-card:hover::after { opacity: 1; }
+  .stat-card.c-yellow::after { background: var(--acc2); }
+  .stat-card.c-mint::after { background: var(--acc3); }
+  .stat-card.c-dim::after { background: var(--dim); }
+  .stat-num {
+    font-family: var(--f-pixel);
+    font-size: 1.8rem;
+    color: var(--ink);
+    line-height: 1;
+    margin-bottom: 0.4rem;
+    letter-spacing: -0.02em;
+  }
+  .stat-label { font-size: 0.68rem; color: var(--dim); letter-spacing: 0.04em; }
+  .stat-icon {
+    position: absolute;
+    top: 0.9rem; right: 1rem;
+    font-size: 1.1rem;
+    opacity: 0.12;
+  }
+
+  /* ── MINI STATS ──────────────────────────── */
+  .mini-stats {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+  }
+  .mini-stat {
+    background: var(--bg);
+    border: 0.5px solid var(--bdr);
+    padding: 0.45rem 0.9rem;
+    font-size: 0.72rem;
+    color: var(--dim);
+  }
+  .mini-stat strong { color: var(--ink); font-weight: 600; }
+
+  /* ── TABLE ───────────────────────────────── */
+  .table-wrap {
+    background: var(--bg);
+    border: 0.5px solid var(--bdr);
+    overflow-x: auto;
+    margin-bottom: 2rem;
+  }
+  table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+  thead tr { border-bottom: 0.5px solid var(--bdr); background: #fdf9f8; }
+  th {
+    padding: 0.7rem 1rem;
+    text-align: left;
+    font-family: var(--f-pixel);
+    font-size: 0.55rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--dim);
+    font-weight: 400;
+    white-space: nowrap;
+  }
+  td {
+    padding: 0.6rem 1rem;
+    border-bottom: 0.5px solid rgba(255,123,138,0.06);
+    vertical-align: middle;
+    color: var(--ink);
+  }
+  tbody tr:last-child td { border-bottom: none; }
+  tbody tr:hover { background: rgba(255,123,138,0.025); }
+
+  /* ── BADGES ──────────────────────────────── */
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--f-pixel);
+    font-size: 0.58rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 2px 8px;
+    white-space: nowrap;
+  }
+  .badge-green  { background: rgba(6,214,160,0.12);  color: var(--acc3); }
+  .badge-red    { background: rgba(255,123,138,0.12); color: var(--acc);  }
+  .badge-gray   { background: rgba(158,148,144,0.12); color: var(--dim);  }
+  .badge-yellow { background: rgba(255,209,102,0.18); color: #997a00;     }
+
+  /* ── SEARCH BAR ──────────────────────────── */
+  .search-bar { display: flex; gap: 0.5rem; margin-bottom: 1rem; }
+  .search-bar input {
+    flex: 1;
+    max-width: 280px;
+    padding: 0.42rem 0.8rem;
+    border: 0.5px solid var(--bdr2);
+    background: var(--bg);
+    color: var(--ink);
+    font-family: inherit;
+    font-size: 0.8rem;
+    outline: none;
+    transition: border-color 0.2s;
+  }
+  .search-bar input:focus { border-color: var(--acc); }
+  .search-bar input::placeholder { color: var(--dim); }
+  .search-bar button {
+    padding: 0.42rem 1rem;
+    background: var(--acc);
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    font-family: var(--f-pixel);
+    font-size: 0.65rem;
+    letter-spacing: 0.1em;
+    transition: opacity 0.2s;
+  }
+  .search-bar button:hover { opacity: 0.82; }
+
+  /* ── TOGGLE BUTTON ───────────────────────── */
+  .btn-toggle {
+    padding: 2px 10px;
+    border: 0.5px solid var(--bdr2);
+    background: transparent;
+    color: var(--dim);
+    font-family: var(--f-pixel);
+    font-size: 0.6rem;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+  }
+  .btn-toggle:hover { border-color: var(--acc); color: var(--acc); }
+  .btn-toggle.is-on { border-color: var(--acc3); color: var(--acc3); }
+
+  /* ── ACTIVITY CARDS (dashboard) ──────────── */
+  .activity-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.2rem;
+    margin-top: 0.5rem;
+  }
+  .activity-card { background: var(--bg); border: 0.5px solid var(--bdr); }
+  .activity-card-header {
+    padding: 0.85rem 1.2rem;
+    border-bottom: 0.5px solid var(--bdr);
+    font-family: var(--f-pixel);
+    font-size: 0.58rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--dim);
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .activity-card-header::before {
+    content: '';
+    display: inline-block;
+    width: 4px; height: 4px;
+    background: var(--acc);
+    border-radius: 50%;
+  }
+  .activity-list { list-style: none; }
+  .activity-list li {
+    padding: 0.65rem 1.2rem;
+    border-bottom: 0.5px solid rgba(255,123,138,0.06);
+    font-size: 0.78rem;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  .activity-list li:last-child { border-bottom: none; }
+  .activity-list li:hover { background: rgba(255,123,138,0.025); }
+  .act-time {
+    font-family: var(--f-pixel);
+    font-size: 0.6rem;
+    color: var(--dim);
+    margin-left: auto;
+    white-space: nowrap;
+  }
+  .tag-user { color: var(--acc); font-family: var(--f-pixel); font-size: 0.6rem; letter-spacing: 0.08em; }
+  .tag-hari { color: var(--acc3); font-family: var(--f-pixel); font-size: 0.6rem; letter-spacing: 0.08em; }
+
+  /* ── UTIL ────────────────────────────────── */
+  .trunc    { max-width: 200px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: inline-block; }
+  .trunc-sm { max-width: 110px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: inline-block; }
+  .empty-state { text-align: center; padding: 2.5rem; color: var(--dim); font-size: 0.78rem; }
+  .dim-text { color: var(--dim); font-size: 0.72rem; }
+  </style>
+</head>
+<body>
+
+<!-- ══════════════════════════════════════════
+     SIDEBAR
+════════════════════════════════════════════ -->
+<nav id="sidebar">
+  <div class="sidebar-header">
+    <img src="{% static 'images/hari_logo.png' %}" alt="Hari">
+    <div class="sidebar-brand">
+      Hari
+      <em>Admin Panel</em>
+    </div>
+  </div>
+
+  <ul class="sidebar-nav">
+    <li class="sidebar-section-label">Overview</li>
+    <li>
+      <a href="?tab=dashboard" class="{% if active_tab == 'dashboard' %}active{% endif %}">
+        <span class="nav-icon">◈</span> 대시보드
+      </a>
+    </li>
+
+    <li class="sidebar-section-label">Management</li>
+    <li>
+      <a href="?tab=users" class="{% if active_tab == 'users' %}active{% endif %}">
+        <span class="nav-icon">◉</span> 사용자 관리
+      </a>
+    </li>
+    <li>
+      <a href="?tab=contents" class="{% if active_tab == 'contents' %}active{% endif %}">
+        <span class="nav-icon">▶</span> 콘텐츠 관리
+      </a>
+    </li>
+    <li>
+      <a href="?tab=knowledge" class="{% if active_tab == 'knowledge' %}active{% endif %}">
+        <span class="nav-icon">◎</span> 하리 지식
+      </a>
+    </li>
+
+    <li class="sidebar-section-label">Logs</li>
+    <li>
+      <a href="?tab=messages" class="{% if active_tab == 'messages' %}active{% endif %}">
+        <span class="nav-icon">◐</span> 채팅 로그
+      </a>
+    </li>
+    <li>
+      <a href="?tab=memories" class="{% if active_tab == 'memories' %}active{% endif %}">
+        <span class="nav-icon">◑</span> 메모리 목록
+      </a>
+    </li>
+  </ul>
+
+  <div class="sidebar-footer">
+    <a href="/">← 홈으로 돌아가기</a>
+  </div>
+</nav>
+
+<!-- ══════════════════════════════════════════
+     TOPBAR
+════════════════════════════════════════════ -->
+<header id="topbar">
+  <div class="topbar-title">
+    {% if active_tab == 'dashboard' %}Dashboard
+    {% elif active_tab == 'users' %}사용자 관리
+    {% elif active_tab == 'contents' %}콘텐츠 관리
+    {% elif active_tab == 'knowledge' %}하리 지식 관리
+    {% elif active_tab == 'messages' %}채팅 로그
+    {% elif active_tab == 'memories' %}메모리 목록
+    {% else %}Dashboard{% endif %}
+  </div>
+  <div class="topbar-user">
+    <span>{{ request.user.username }}</span>
+    <span class="topbar-badge">Staff</span>
+  </div>
+</header>
+
+<!-- ══════════════════════════════════════════
+     MAIN
+════════════════════════════════════════════ -->
+<main id="main">
+  <div class="content-area">
+
+  <!-- ─────────────────────────────────────────
+       DASHBOARD
+  ───────────────────────────────────────── -->
+  {% if active_tab == 'dashboard' %}
+
+    <div class="section-title">Overview</div>
+    <div class="stats-grid">
+      <div class="stat-card">
+        <div class="stat-icon">👥</div>
+        <div class="stat-num">{{ total_users }}</div>
+        <div class="stat-label">총 사용자</div>
+      </div>
+      <div class="stat-card c-yellow">
+        <div class="stat-icon">📍</div>
+        <div class="stat-num">{{ today_visits }}</div>
+        <div class="stat-label">오늘 방문</div>
+      </div>
+      <div class="stat-card c-mint">
+        <div class="stat-icon">💬</div>
+        <div class="stat-num">{{ total_messages }}</div>
+        <div class="stat-label">총 메시지</div>
+      </div>
+      <div class="stat-card c-dim">
+        <div class="stat-icon">🎬</div>
+        <div class="stat-num">{{ published_contents }}</div>
+        <div class="stat-label">발행된 콘텐츠</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-icon">🧠</div>
+        <div class="stat-num">{{ total_knowledge }}</div>
+        <div class="stat-label">지식 항목</div>
+      </div>
+      <div class="stat-card c-yellow">
+        <div class="stat-icon">🗂</div>
+        <div class="stat-num">{{ total_memories }}</div>
+        <div class="stat-label">대화 메모리</div>
+      </div>
+    </div>
+
+    <div class="section-title">Recent Activity</div>
+    <div class="activity-grid">
+      <div class="activity-card">
+        <div class="activity-card-header">최근 가입 사용자</div>
+        <ul class="activity-list">
+          {% for u in recent_users %}
+          <li>
+            <span>{{ u.username }}</span>
+            {% if u.is_staff %}<span class="badge badge-yellow">Staff</span>{% endif %}
+            <span class="act-time">{{ u.date_joined|date:"m.d H:i" }}</span>
+          </li>
+          {% empty %}
+          <li style="color:var(--dim); justify-content:center;">사용자 없음</li>
+          {% endfor %}
+        </ul>
+      </div>
+
+      <div class="activity-card">
+        <div class="activity-card-header">최근 채팅 메시지</div>
+        <ul class="activity-list">
+          {% for msg in recent_messages %}
+          <li>
+            {% if msg.sender_type %}
+            <span class="tag-user">USER</span>
+            {% else %}
+            <span class="tag-hari">HARI</span>
+            {% endif %}
+            <span class="trunc" style="max-width:160px; flex:1;">{{ msg.content }}</span>
+            <span class="act-time">{{ msg.created_at|date:"m.d H:i" }}</span>
+          </li>
+          {% empty %}
+          <li style="color:var(--dim); justify-content:center;">메시지 없음</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+
+  <!-- ─────────────────────────────────────────
+       USERS
+  ───────────────────────────────────────── -->
+  {% elif active_tab == 'users' %}
+
+    <form class="search-bar" method="get" action="">
+      <input type="hidden" name="tab" value="users">
+      <input type="text" name="search_user" value="{{ search_user }}" placeholder="사용자명 검색...">
+      <button type="submit">검색</button>
+    </form>
+
+    <div class="mini-stats">
+      <div class="mini-stat">전체 <strong>{{ total_users }}</strong>명</div>
+      {% if search_user %}<div class="mini-stat">검색 결과 <strong>{{ users|length }}</strong>명</div>{% endif %}
+    </div>
+
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Username</th>
+            <th>Email</th>
+            <th>가입일</th>
+            <th>마지막 로그인</th>
+            <th>Staff</th>
+            <th>상태</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for u in users %}
+          <tr>
+            <td class="dim-text">{{ u.id }}</td>
+            <td><strong>{{ u.username }}</strong></td>
+            <td class="dim-text">{{ u.email|default:"—" }}</td>
+            <td class="dim-text">{{ u.date_joined|date:"Y.m.d" }}</td>
+            <td class="dim-text">{{ u.last_login|date:"Y.m.d H:i"|default:"—" }}</td>
+            <td>
+              {% if u.is_staff %}
+              <span class="badge badge-yellow">Staff</span>
+              {% else %}
+              <span class="badge badge-gray">—</span>
+              {% endif %}
+            </td>
+            <td>
+              {% if u.is_active %}
+              <span class="badge badge-green">Active</span>
+              {% else %}
+              <span class="badge badge-red">Inactive</span>
+              {% endif %}
+            </td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="7" class="empty-state">사용자가 없습니다.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+  <!-- ─────────────────────────────────────────
+       CONTENTS
+  ───────────────────────────────────────── -->
+  {% elif active_tab == 'contents' %}
+
+    <div class="mini-stats">
+      <div class="mini-stat">전체 <strong>{{ total_contents }}</strong>개</div>
+      <div class="mini-stat">발행됨 <strong>{{ published_contents }}</strong>개</div>
+    </div>
+
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Title</th>
+            <th>Platform</th>
+            <th>Summary</th>
+            <th>발행 상태</th>
+            <th>생성일</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for c in contents %}
+          <tr>
+            <td class="dim-text">{{ c.content_id }}</td>
+            <td><span class="trunc">{{ c.title|default:"untitled" }}</span></td>
+            <td>
+              {% if c.platform %}
+              <span class="badge badge-gray">{{ c.platform }}</span>
+              {% else %}<span class="dim-text">—</span>{% endif %}
+            </td>
+            <td><span class="trunc">{{ c.summary|default:"—" }}</span></td>
+            <td>
+              {% if c.is_published %}
+              <span class="badge badge-green" id="pub-badge-{{ c.content_id }}">Published</span>
+              {% else %}
+              <span class="badge badge-gray" id="pub-badge-{{ c.content_id }}">Draft</span>
+              {% endif %}
+            </td>
+            <td class="dim-text">{{ c.created_at|date:"Y.m.d" }}</td>
+            <td>
+              <button class="btn-toggle {% if c.is_published %}is-on{% endif %}"
+                      onclick="toggleContent({{ c.content_id }}, this)">
+                {% if c.is_published %}발행 취소{% else %}발행{% endif %}
+              </button>
+            </td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="7" class="empty-state">콘텐츠가 없습니다.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+  <!-- ─────────────────────────────────────────
+       KNOWLEDGE
+  ───────────────────────────────────────── -->
+  {% elif active_tab == 'knowledge' %}
+
+    <div class="mini-stats">
+      <div class="mini-stat">전체 <strong>{{ total_knowledge }}</strong>개</div>
+    </div>
+
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Category</th>
+            <th>Key</th>
+            <th>Value</th>
+            <th>Active</th>
+            <th>Updated</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for k in hari_knowledge %}
+          <tr>
+            <td class="dim-text">{{ k.persona_id }}</td>
+            <td><span class="badge badge-gray">{{ k.category|default:"—" }}</span></td>
+            <td style="font-size:0.78rem;">{{ k.trait_key|default:"—" }}</td>
+            <td><span class="trunc">{{ k.trait_value|default:"—" }}</span></td>
+            <td>
+              {% if k.is_active %}
+              <span class="badge badge-green" id="ka-badge-{{ k.persona_id }}">Active</span>
+              {% else %}
+              <span class="badge badge-red" id="ka-badge-{{ k.persona_id }}">Inactive</span>
+              {% endif %}
+            </td>
+            <td class="dim-text">{{ k.updated_at|date:"m.d H:i" }}</td>
+            <td>
+              <button class="btn-toggle {% if k.is_active %}is-on{% endif %}"
+                      onclick="toggleKnowledge({{ k.persona_id }}, this)">
+                {% if k.is_active %}비활성화{% else %}활성화{% endif %}
+              </button>
+            </td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="7" class="empty-state">지식 항목이 없습니다.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+  <!-- ─────────────────────────────────────────
+       MESSAGES
+  ───────────────────────────────────────── -->
+  {% elif active_tab == 'messages' %}
+
+    <div class="mini-stats">
+      <div class="mini-stat">총 메시지 <strong>{{ total_messages }}</strong>개 (최근 100개 표시)</div>
+    </div>
+
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Sender</th>
+            <th>User</th>
+            <th>Content</th>
+            <th>Session</th>
+            <th>시간</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for msg in all_messages %}
+          <tr>
+            <td class="dim-text">{{ msg.message_id }}</td>
+            <td>
+              {% if msg.sender_type %}
+              <span class="badge badge-red">User</span>
+              {% else %}
+              <span class="badge badge-green">Hari</span>
+              {% endif %}
+            </td>
+            <td class="dim-text">{{ msg.user.username|default:"—" }}</td>
+            <td><span class="trunc">{{ msg.content }}</span></td>
+            <td class="dim-text"><span class="trunc-sm">{{ msg.session_id|default:"—" }}</span></td>
+            <td class="dim-text">{{ msg.created_at|date:"m.d H:i" }}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="6" class="empty-state">메시지가 없습니다.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+  <!-- ─────────────────────────────────────────
+       MEMORIES
+  ───────────────────────────────────────── -->
+  {% elif active_tab == 'memories' %}
+
+    <div class="mini-stats">
+      <div class="mini-stat">총 메모리 <strong>{{ total_memories }}</strong>개</div>
+    </div>
+
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>User</th>
+            <th>Summary</th>
+            <th>Keywords</th>
+            <th>Session</th>
+            <th>종료 시간</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for mem in chat_memories %}
+          <tr>
+            <td class="dim-text">{{ mem.memory_id }}</td>
+            <td>{{ mem.user.username|default:"—" }}</td>
+            <td><span class="trunc">{{ mem.summary|default:"—" }}</span></td>
+            <td><span class="trunc">{{ mem.keywords|default:"—" }}</span></td>
+            <td class="dim-text"><span class="trunc-sm">{{ mem.session_id|default:"—" }}</span></td>
+            <td class="dim-text">{{ mem.ended_at|date:"m.d H:i"|default:"—" }}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="6" class="empty-state">메모리가 없습니다.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+  {% endif %}
+
+  </div><!-- /.content-area -->
+</main>
+
+<script>
+const CSRF = '{{ csrf_token }}';
+
+async function toggleContent(id, btn) {
+  try {
+    const res = await fetch(`/admin-panel/content/${id}/toggle/`, {
+      method: 'POST',
+      headers: { 'X-CSRFToken': CSRF }
+    });
+    const data = await res.json();
+    if (!data.ok) return;
+    const badge = document.getElementById(`pub-badge-${id}`);
+    if (data.is_published) {
+      badge.className = 'badge badge-green';
+      badge.textContent = 'Published';
+      btn.textContent = '발행 취소';
+      btn.classList.add('is-on');
+    } else {
+      badge.className = 'badge badge-gray';
+      badge.textContent = 'Draft';
+      btn.textContent = '발행';
+      btn.classList.remove('is-on');
+    }
+  } catch (e) { console.error(e); }
+}
+
+async function toggleKnowledge(id, btn) {
+  try {
+    const res = await fetch(`/admin-panel/knowledge/${id}/toggle/`, {
+      method: 'POST',
+      headers: { 'X-CSRFToken': CSRF }
+    });
+    const data = await res.json();
+    if (!data.ok) return;
+    const badge = document.getElementById(`ka-badge-${id}`);
+    if (data.is_active) {
+      badge.className = 'badge badge-green';
+      badge.textContent = 'Active';
+      btn.textContent = '비활성화';
+      btn.classList.add('is-on');
+    } else {
+      badge.className = 'badge badge-red';
+      badge.textContent = 'Inactive';
+      btn.textContent = '활성화';
+      btn.classList.remove('is-on');
+    }
+  } catch (e) { console.error(e); }
+}
+</script>
+</body>
+</html>

--- a/backend/templates/frontend/homepage.html
+++ b/backend/templates/frontend/homepage.html
@@ -147,6 +147,26 @@ body { background:var(--bg); color:var(--ink); font-family:var(--f-thin); font-s
 #auth-btn.logged-in { border-color:var(--grn); color:var(--grn); }
 #auth-btn.logged-in:hover { background:var(--grn); color:#fff; border-color:var(--grn); }
 
+/* ── USER DROPDOWN ── */
+.auth-user-wrap { position:relative; margin-left:1.4rem; flex-shrink:0; }
+.user-dropdown {
+  position:absolute; top:calc(100% + 8px); right:0;
+  background:var(--bg); border:0.5px solid var(--bdr2);
+  min-width:130px; z-index:300;
+  display:none; flex-direction:column;
+  box-shadow:0 4px 20px rgba(42,36,32,0.1);
+}
+.user-dropdown.show { display:flex; }
+.user-dropdown a, .user-dropdown button {
+  display:block; width:100%; padding:0.6rem 1rem;
+  text-align:left; color:var(--ink); text-decoration:none;
+  font-size:0.78rem; background:transparent; border:none;
+  cursor:pointer; font-family:inherit; letter-spacing:0.02em;
+  transition:background 0.2s;
+}
+.user-dropdown a:hover, .user-dropdown button:hover { background:rgba(255,123,138,0.08); }
+.user-dropdown .logout-btn { color:var(--acc); border-top:0.5px solid var(--bdr); }
+
 /* ── AUTH MODAL ── */
 #auth-overlay {
   position:fixed; inset:0; z-index:500;
@@ -1317,6 +1337,22 @@ function doForgot(){
 }
 function socialLogin(provider){
   window.location.href='/accounts/'+provider+'/login/?process=login';
+}
+function toggleUserMenu(){
+  document.getElementById('user-dropdown').classList.toggle('show');
+}
+document.addEventListener('click',function(e){
+  const wrap=document.getElementById('user-menu-wrap');
+  if(wrap&&!wrap.contains(e.target)){
+    const dd=document.getElementById('user-dropdown');
+    if(dd) dd.classList.remove('show');
+  }
+});
+function doLogout(){
+  fetch('/api/auth/logout/',{
+    method:'POST',
+    headers:{'X-CSRFToken':getCookie('csrftoken'),'Content-Type':'application/json'}
+  }).finally(()=>{ window.location.href='/'; });
 }
 document.addEventListener('keydown',e=>{ if(e.key==='Escape') closeAuth(); });
 

--- a/backend/templates/frontend/includes/homepage/_nav_auth.html
+++ b/backend/templates/frontend/includes/homepage/_nav_auth.html
@@ -23,9 +23,15 @@
     </div>
 
 
-    <!-- 로그인 버튼 -->
+    <!-- 로그인/유저 버튼 -->
     {% if user.is_authenticated %}
-    <button id="auth-btn" class="logged-in" onclick="window.location.href='/fanpage/'">{{ user.username }}</button>
+    <div class="auth-user-wrap" id="user-menu-wrap">
+      <button id="auth-btn" class="logged-in" onclick="toggleUserMenu()">{{ user.username }} ▾</button>
+      <div class="user-dropdown" id="user-dropdown">
+        <a href="/fanpage/">마이페이지</a>
+        <button class="logout-btn" onclick="doLogout()">로그아웃</button>
+      </div>
+    </div>
     {% else %}
     <button id="auth-btn" onclick="openAuth('login')">로그인</button>
     {% endif %}
@@ -58,6 +64,11 @@
     <a href="#s-sub" onclick="closeDrawer()" style="display:flex;align-items:center;justify-content:space-between;padding:.7rem .9rem;background:var(--acc);color:var(--ink);font-family:'DM Mono',monospace;font-size:.62rem;letter-spacing:.14em;text-transform:uppercase;text-decoration:none;margin-top:.5rem;transition:background .2s;">
       <span>멤버십 가입하기</span><span>↗</span>
     </a>
+    {% if user.is_authenticated %}
+    <button onclick="doLogout()" style="display:flex;align-items:center;justify-content:space-between;width:100%;padding:.7rem .9rem;background:transparent;border:0.5px solid rgba(255,123,138,0.3);color:var(--acc);font-family:'DM Mono',monospace;font-size:.62rem;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;margin-top:.5rem;transition:background .2s;" onmouseover="this.style.background='rgba(255,123,138,0.1)'" onmouseout="this.style.background='transparent'">
+      <span>로그아웃</span><span>→</span>
+    </button>
+    {% endif %}
     <p>하리 팬클럽 —<br>더 가깝게, 더 특별하게</p>
   </div>
 </div>


### PR DESCRIPTION
- /admin-panel/ 관리자 페이지 신규 생성 (staff 전용)
  - 대시보드: 사용자·방문·메시지·콘텐츠·지식·메모리 통계
  - 사용자 관리, 콘텐츠 관리, 하리 지식, 채팅 로그, 메모리 목록 탭
  - 콘텐츠 발행·지식 활성화 AJAX 토글
- 홈페이지 네브바에 로그아웃 드롭다운 추가
  - 로그인 상태: 유저명 클릭 시 마이페이지 / 로그아웃 메뉴 표시
  - 햄버거 드로어에도 로그아웃 버튼 추가