### PR TITLE
feat: 로컬 개발 환경에서 비로그인 채팅 및 날짜 구분선 개선

### DIFF
--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -41,17 +41,23 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
     async def connect(self):
         try:
+            from django.conf import settings
             user = self.scope["user"]
 
             if not user.is_authenticated:
-                await self.close(code=4401)
-                return
+                if not settings.DEBUG:
+                    await self.close(code=4401)
+                    return
+                # 로컬 개발 전용 guest 모드
+                self.user_id = None
+                self.thread_id = 'guest'
+                self.message_count = 0
+            else:
+                self.user_id = user.id
+                self.thread_id = str(user.id)
+                self.message_count = 0
 
             self.session_messages = []
-            self.user_id = user.id
-            self.thread_id = str(user.id)
-
-            # Generate a session_id for this conversation
             import uuid
             url_session = self.scope['url_route']['kwargs'].get('session_id')
             self.session_id = str(url_session) if url_session else str(uuid.uuid4())
@@ -60,11 +66,15 @@ class ChatConsumer(AsyncWebsocketConsumer):
             await self.channel_layer.group_add(self.room_group_name, self.channel_name)
             await self.accept()
 
-            # Get current message count so we continue the sequence correctly
-            self.message_count = await self.get_message_count()
+            # DB에서 메시지 수 조회 (guest 모드거나 DB 없으면 0 유지)
+            if self.user_id is not None:
+                try:
+                    self.message_count = await self.get_message_count()
+                except Exception:
+                    self.message_count = 0
+
             logger.info(f"WS connected: thread={self.thread_id}, message_count={self.message_count}")
 
-            # Pick greeting based on whether we know the user
             greeting = await self._pick_greeting()
             await self.send(text_data=json.dumps({
                 'message': greeting,
@@ -203,11 +213,12 @@ class ChatConsumer(AsyncWebsocketConsumer):
     @database_sync_to_async
     def save_message(self, sender_type, content):
         self.message_count += 1
-        # Track in session first — even if the DB write fails the memory summary still works
         self.session_messages.append({
             'sender': 'user' if sender_type else 'hari',
             'content': content,
         })
+        if self.user_id is None:
+            return  # guest 모드 — DB 저장 skip
         Message.objects.create(
             user_id=self.user_id,
             sender_type=sender_type,
@@ -222,6 +233,9 @@ class ChatConsumer(AsyncWebsocketConsumer):
         Persist a summary of this conversation session to chat_memory.
         Returns the total number of conversations this user has had.
         """
+        if self.user_id is None:
+            return 0  # guest 모드 — DB 저장 skip
+
         # Build conversation transcript
         lines = [
             f"{'User' if m['sender'] == 'user' else 'Hari'}: {m['content']}"

--- a/backend/templates/frontend/chat.html
+++ b/backend/templates/frontend/chat.html
@@ -1096,6 +1096,7 @@ html, body {
 <script id="django-data" type="application/json">
   {
     "isAuthenticated": {% if user.is_authenticated %}true{% else %}false{% endif %},
+    "isDebug": {% if debug %}true{% else %}false{% endif %},
     "userName": "{{ user.username|default:'' }}",
     "loginUrl": "{% url 'home' %}",
     "csrfToken": "{{ csrf_token }}"
@@ -1109,7 +1110,7 @@ html, body {
  * ═══════════════════════════════════════
  */
 const djangoData = JSON.parse(document.getElementById('django-data').textContent);
-const { isAuthenticated, userName, loginUrl, csrfToken } = djangoData;
+const { isAuthenticated, isDebug, userName, loginUrl, csrfToken } = djangoData;
 
 const protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
 let chatSocket = null;
@@ -1199,7 +1200,7 @@ function sendMessage() {
   const text = input.value.trim();
   if (!text) return;
   
-  if (!isAuthenticated) {
+  if (!isAuthenticated && !isDebug) {
     alert('로그인이 필요해! 🌸');
     window.location.href = loginUrl;
     return;
@@ -1255,9 +1256,9 @@ function splitMessage(text) {
 }
 
 function renderSingleHariBubble(text, options = {}) {
-  const { isFirst = true, isLast = true, animate = true } = options;
+  const { isFirst = true, isLast = true, animate = true, timestamp = null } = options;
   const messages = document.getElementById('messages');
-  const now = new Date();
+  const now = timestamp ? new Date(timestamp) : new Date();
   const timeStr = formatTime(now);
   const dateKey = checkAndAddDateDivider(now);
   
@@ -1281,14 +1282,14 @@ function renderSingleHariBubble(text, options = {}) {
   scrollToBottom(animate);
 }
 
-function appendHariMessage(text, isHistory = false) {
+function appendHariMessage(text, isHistory = false, timestamp = null) {
   const segments = splitMessage(text);
   if (segments.length === 0) return;
 
   if (isHistory) {
     hideTyping();
     segments.forEach((seg, i) => {
-      renderSingleHariBubble(seg, { isFirst: i === 0, isLast: i === segments.length - 1, animate: false });
+      renderSingleHariBubble(seg, { isFirst: i === 0, isLast: i === segments.length - 1, animate: false, timestamp });
     });
     return;
   }
@@ -1329,9 +1330,9 @@ function scheduleNextBubble() {
  * ═══════════════════════════════════════
  */
 
-function addMessage(sender, content, type = 'text') {
+function addMessage(sender, content, type = 'text', timestamp = null) {
   const messages = document.getElementById('messages');
-  const now = new Date();
+  const now = timestamp ? new Date(timestamp) : new Date();
   const dateKey = checkAndAddDateDivider(now);
   const timeStr = formatTime(now);
   const displayContent = type === 'text' ? escapeHtml(content) : content;
@@ -1380,7 +1381,7 @@ function checkAndAddDateDivider(date) {
 function formatTime(date) {
   let hours = date.getHours();
   const minutes = date.getMinutes();
-  const ampm = hours >= 12 ? 'PM' : 'AM';
+  const ampm = hours >= 12 ? '오후' : '오전';
   hours = hours % 12 || 12;
   return `${ampm} ${hours}:${String(minutes).padStart(2, '0')}`;
 }
@@ -1525,9 +1526,9 @@ async function loadHistory() {
     if (messages.length > 0) {
       messages.forEach(msg => {
         if (msg.sender_type) {
-          addMessage('me', msg.content);
+          addMessage('me', msg.content, 'text', msg.created_at);
         } else {
-          appendHariMessage(msg.content, true);
+          appendHariMessage(msg.content, true, msg.created_at);
         }
       });
     }


### PR DESCRIPTION
- 로컬(DEBUG=True)에서 비로그인 시 guest 모드로 WebSocket 연결 허용
  - DB 저장(메시지, 메모리) skip, 서버 배포 시 기존 인증 로직 그대로 유지
- 채팅 메시지 시간 형식 AM/PM → 오전/오후 (카카오톡 형식)
- 과거 메시지 로드 시 실제 created_at 기준으로 날짜 구분선 표시
- 날짜가 바뀔 때마다 자동 날짜 구분선 삽입