### PR TITLE
fix: EB 재배포 시 동일 버전 레이블 충돌 방지

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -41,6 +41,7 @@ jobs:
           region: ${{ env.AWS_REGION }}
           deployment_package: deploy.zip
           wait_for_deployment: true
+          use_existing_version_if_available: true
 
       - name: Get EB Environment Info
         id: get-info


### PR DESCRIPTION
동일 커밋 SHA로 재배포 시도 시 이미 존재하는 버전 레이블로 인해
배포가 실패하는 문제를 해결하기 위해 use_existing_version_if_available: true 추가