### PR TITLE
fix: EB 서버 SQLite 오버라이드 문제 해결중

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -4,8 +4,6 @@ services:
   web:
     build: .
     command: sh -c "python manage.py migrate --noinput && daphne -b 0.0.0.0 -p 8000 config.asgi:application"
-    volumes:
-      - .:/app
     ports:
       - "80:8000"
       - "8000:8000"


### PR DESCRIPTION
[핵심 원인]
volumes: - .:/app 바인드 마운트가 호스트 디렉토리를 컨테이너에
덮어씌워 .dockerignore를 무력화하고 local_settings.py를 재주입,
SQLite로 오버라이드되던 문제 수정.

[변경 사항]
- volumes: - .:/app 제거 (EB 프로덕션에서 불필요)
- .dockerignore: local_settings.py Docker 빌드 시 제외
- docker-compose environment: EB 환경변수를 컨테이너로 명시 전달 (DB_HOST 등 RDS 접속 정보가 env_file 값을 올바르게 덮어씀)