### PR TITLE
feat: 비로그인 사용자 채팅 버튼 클릭 시 로그인 모달 유도

### DIFF
--- a/backend/templates/frontend/homepage.html
+++ b/backend/templates/frontend/homepage.html
@@ -1418,11 +1418,9 @@ function qSend(t){ document.getElementById('ci').value=t; doSend(); }
 function ckKey(e){ if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();doSend();} }
 function aRz(el){ el.style.height='auto'; el.style.height=Math.min(el.scrollHeight,100)+'px'; }
 
-/* 하리 대화 페이지 링크 — URL 연결 시 아래 href를 교체하세요 */
-const CHAT_URL = '/hari-chat/';
-document.getElementById('chat-page-link').href = CHAT_URL;
+/* 하리 대화 페이지 링크 — 비로그인 시 로그인 모달 오픈 */
 document.getElementById('chat-page-link').addEventListener('click', function(e){
-  if(this.getAttribute('href') === '#'){ e.preventDefault(); alert('하리 대화 페이지를 준비 중이에요.\n곧 오픈 예정입니다! 🙏'); }
+  if(this.getAttribute('href') === '#'){ e.preventDefault(); openAuth('login'); }
 });
 function planSelect(btn,tier){ btn.textContent='처리 중...'; setTimeout(()=>{ btn.textContent=`${tier.toUpperCase()} 가입 완료! ✓`; btn.style.background='#2e8b52'; btn.style.borderColor='#2e8b52'; btn.style.color='#fff'; setTimeout(()=>{ btn.textContent=tier==='free'?'무료로 시작하기 →':tier==='fan+'?'Fan+ 시작하기 →':'VIP 시작하기 →'; btn.style.background=''; btn.style.borderColor=''; btn.style.color=''; },3000); },800); }
 

--- a/backend/templates/frontend/includes/homepage/_nav_auth.html
+++ b/backend/templates/frontend/includes/homepage/_nav_auth.html
@@ -8,7 +8,11 @@
   <div class="nav-center">
     <!-- 상단 GNB 메뉴 (이전 언어/시간 위치) -->
     <div class="nav-desktop-menu" style="display:flex; align-items:center; gap:1.1rem; margin-right:auto; margin-left:2rem; font-family:var(--f-playful); font-size:0.85rem; letter-spacing:0.01em; text-transform:uppercase;">
+      {% if user.is_authenticated %}
       <a href="/hari-chat/" style="color:var(--acc);text-decoration:none;font-weight:600;display:flex;align-items:center;gap:0.3rem;white-space:nowrap;">하리와 대화하기 <span style="font-size:1rem;">💬</span></a>
+      {% else %}
+      <a href="#" onclick="openAuth('login'); return false;" style="color:var(--acc);text-decoration:none;font-weight:600;display:flex;align-items:center;gap:0.3rem;white-space:nowrap;">하리와 대화하기 <span style="font-size:1rem;">💬</span></a>
+      {% endif %}
       <a href="#s2" style="color:var(--ink);text-decoration:none;transition:opacity 0.2s;white-space:nowrap;" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=1">Profile <sup style="color:var(--dim); font-family:var(--f-pixel); font-size:0.6rem;">01</sup></a>
       <a href="#s3" style="color:var(--ink);text-decoration:none;transition:opacity 0.2s;white-space:nowrap;" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=1">Gallery <sup style="color:var(--dim); font-family:var(--f-pixel); font-size:0.6rem;">02</sup></a>
       <a href="#s4" style="color:var(--ink);text-decoration:none;transition:opacity 0.2s;white-space:nowrap;" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=1">Chat <sup style="color:var(--dim); font-family:var(--f-pixel); font-size:0.6rem;">03</sup></a>
@@ -52,7 +56,11 @@
 <div id="drawer">
   <div class="drawer-label">Navigation</div>
   <ul>
+    {% if user.is_authenticated %}
     <li><a href="/hari-chat/" onclick="closeDrawer()"><span style="color:var(--acc);font-weight:600;">하리와 대화하기</span></a></li>
+    {% else %}
+    <li><a href="#" onclick="closeDrawer(); openAuth('login'); return false;"><span style="color:var(--acc);font-weight:600;">하리와 대화하기</span></a></li>
+    {% endif %}
     <li><a href="#s2" onclick="closeDrawer()"><span>Profile</span><span class="d-num">01</span></a></li>
     <li><a href="#s3" onclick="closeDrawer()"><span>Gallery</span><span class="d-num">02</span></a></li>
     <li><a href="#s4" onclick="closeDrawer()"><span>Chat</span><span class="d-num">03</span></a></li>

--- a/backend/templates/frontend/includes/homepage/_s4_chat.html
+++ b/backend/templates/frontend/includes/homepage/_s4_chat.html
@@ -50,9 +50,15 @@
       </div>
 
       <div class="chat-left-bottom">
+        {% if user.is_authenticated %}
         <a class="chat-cta-btn" href="/hari-chat/" id="chat-page-link">
           하리와 대화 시작하기 <span>→</span>
         </a>
+        {% else %}
+        <a class="chat-cta-btn" href="#" id="chat-page-link" onclick="openAuth('login'); return false;">
+          하리와 대화 시작하기 <span>→</span>
+        </a>
+        {% endif %}
         <div class="chat-coming">하리와 직접 대화해보세요 💬</div>
       </div>
     </div>


### PR DESCRIPTION
- 네비게이션, 모바일 드로어, 섹션4 CTA의 '하리와 대화하기' 버튼을 비로그인 상태에서 클릭하면 /hari-chat/ 이동 대신 로그인 모달 오픈
- homepage.html JS에서 기존 alert('준비 중') 제거 및 openAuth('login') 호출로 교체