### PR TITLE
fix: Dockerfile에 collectstatic 추가하여 서버 정적 파일 미적용 문제 해결

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,4 +31,4 @@ COPY . /app/
 EXPOSE 8000
 
 # Run Daphne (ASGI server) for handling both HTTP and WebSockets
-CMD ["daphne", "-b", "0.0.0.0", "-p", "8000", "config.asgi:application"]
+CMD ["sh", "-c", "python manage.py migrate --noinput && python manage.py collectstatic --noinput && daphne -b 0.0.0.0 -p 8000 config.asgi:application"]

--- a/backend/config/local_settings.py
+++ b/backend/config/local_settings.py
@@ -1,6 +1,0 @@
-# 로컬에서 레디스가 없을 때를 대비해 메모리 채널 레이어 사용
-CHANNEL_LAYERS = {
-    'default': {
-        'BACKEND': 'channels.layers.InMemoryChannelLayer',
-    }
-}


### PR DESCRIPTION
배포 시 collectstatic이 실행되지 않아 파비콘 등 정적 파일이
서버에서 서빙되지 않던 문제 수정.
migrate → collectstatic → daphne 순서로 실행되도록 CMD 변경.