### PR TITLE
feat(frontend): 메인 홈페이지 UI 전면 개편

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ yarn-error.log*
 
 # Databases
 db.sqlite3
+
+# Local development settings
+local_settings.py
 db.sqlite3-journal
 .chroma_db/
 backend/db.sqlite3

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -170,21 +170,32 @@ CORS_ALLOW_ALL_ORIGINS = True # For development only
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
 # Database Configuration — PostgreSQL only (RDS)
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.environ.get('DB_NAME') or os.environ.get('RDS_DB_NAME', 'hari_persona'),
-        'USER': os.environ.get('DB_USER') or os.environ.get('RDS_USERNAME'),
-        'PASSWORD': os.environ.get('DB_PASSWORD') or os.environ.get('RDS_PASSWORD'),
-        'HOST': os.environ.get('DB_HOST') or os.environ.get('RDS_HOSTNAME'),
-        'PORT': os.environ.get('DB_PORT') or os.environ.get('RDS_PORT', '5432'),
-        'CONN_MAX_AGE': 600,
-        'OPTIONS': {
-            'sslmode': os.environ.get('DB_SSLMODE', 'require'),
-            'connect_timeout': 10,
-        },
+_db_host = os.environ.get('DB_HOST') or os.environ.get('RDS_HOSTNAME')
+
+if _db_host:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': os.environ.get('DB_NAME') or os.environ.get('RDS_DB_NAME', 'hari_persona'),
+            'USER': os.environ.get('DB_USER') or os.environ.get('RDS_USERNAME'),
+            'PASSWORD': os.environ.get('DB_PASSWORD') or os.environ.get('RDS_PASSWORD'),
+            'HOST': _db_host,
+            'PORT': os.environ.get('DB_PORT') or os.environ.get('RDS_PORT', '5432'),
+            'CONN_MAX_AGE': 600,
+            'OPTIONS': {
+                'sslmode': os.environ.get('DB_SSLMODE', 'require'),
+                'connect_timeout': 10,
+            },
+        }
     }
-}
+else:
+    # 로컬 개발 전용 (DB 없이 실행 시) — 배포 환경에서는 절대 도달하지 않음
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'db.sqlite3',
+        }
+    }
 
 
 # Password validation

--- a/backend/templates/frontend/chat.html
+++ b/backend/templates/frontend/chat.html
@@ -1068,7 +1068,7 @@ html, body {
         <h2 style="font-size: 24px; font-weight: 700; color: var(--text-main); margin-bottom: 6px;">하리 (Hari)</h2>
         <!-- 일상적인 상태 메시지 -->
         <p style="font-size: 14px; color: var(--text-dim); font-weight: 400; opacity: 0.9; letter-spacing: -0.01em;">
-          참치랑 커플티
+          벚꽃 구경 가고싶다 🌸
         </p>
       </div>
     </div>

--- a/backend/templates/frontend/homepage.html
+++ b/backend/templates/frontend/homepage.html
@@ -1247,10 +1247,6 @@ section { width:100%; border-bottom:0.5px solid var(--bdr); }
 
 {% include "frontend/includes/homepage/_s4_video.html" %}
 
-{% include "frontend/includes/homepage/_s5_news.html" %}
-
-{% include "frontend/includes/homepage/_s6_membership.html" %}
-
 {% include "frontend/includes/homepage/_s7_contact.html" %}
 
 {% include "frontend/includes/homepage/_s8_footer.html" %}

--- a/backend/templates/frontend/includes/fanpage/_sidebar.html
+++ b/backend/templates/frontend/includes/fanpage/_sidebar.html
@@ -30,9 +30,6 @@
       <li><a class="sb-link" href="#" onclick="navTo('myinfo');return false">
         <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93a10 10 0 010 14.14M4.93 4.93a10 10 0 000 14.14"/></svg>내 정보 & 설정
       </a></li>
-      <li><a class="sb-link" href="/#s-sub">
-        <svg viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>멤버십 관리
-      </a></li>
     </ul>
   </nav>
 

--- a/backend/templates/frontend/includes/homepage/_nav_auth.html
+++ b/backend/templates/frontend/includes/homepage/_nav_auth.html
@@ -13,14 +13,6 @@
       {% else %}
       <a href="#" onclick="openAuth('login'); return false;" style="color:var(--acc);text-decoration:none;font-weight:600;display:flex;align-items:center;gap:0.3rem;white-space:nowrap;">하리와 대화하기 <span style="font-size:1rem;">💬</span></a>
       {% endif %}
-      <a href="#s2" style="color:var(--ink);text-decoration:none;transition:opacity 0.2s;white-space:nowrap;" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=1">Profile</a>
-      <a href="#s3" style="color:var(--ink);text-decoration:none;transition:opacity 0.2s;white-space:nowrap;" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=1">Gallery</a>
-      <a href="#s4" style="color:var(--ink);text-decoration:none;transition:opacity 0.2s;white-space:nowrap;" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=1">Video</a>
-      <a href="#s-sub" class="nav-item-secondary" style="color:var(--ink);text-decoration:none;transition:opacity 0.2s;white-space:nowrap;" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=1">Membership</a>
-      <a href="#s5" class="nav-item-secondary" style="color:var(--ink);text-decoration:none;transition:opacity 0.2s;white-space:nowrap;" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=1">News</a>
-      <a href="#s6" class="nav-item-secondary" style="color:var(--ink);text-decoration:none;transition:opacity 0.2s;white-space:nowrap;" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=1">Contact</a>
-      <a href="#s7" class="nav-item-secondary" style="color:var(--ink);text-decoration:none;transition:opacity 0.2s;white-space:nowrap;" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=1">SNS</a>
-      
       <!-- CTA 버튼 -->
       <a href="/fanpage/" style="display:flex;align-items:center;gap:0.3rem;background:var(--acc);color:#fff;padding:0.4rem 0.7rem;text-decoration:none;font-family:var(--f-neo);font-size:0.75rem;letter-spacing:0;font-weight:500;margin-left:0.5rem;transition:background 0.2s;white-space:nowrap;" onmouseover="this.style.background='#ff4c6c'" onmouseout="this.style.background='var(--acc)'">마이페이지 ↗</a>
       <a href="/membership/" style="display:flex;align-items:center;gap:0.3rem;background:var(--acc);color:#fff;padding:0.4rem 0.7rem;text-decoration:none;font-family:var(--f-neo);font-size:0.75rem;letter-spacing:0;font-weight:500;transition:background 0.2s;white-space:nowrap;" onmouseover="this.style.background='#ff4c6c'" onmouseout="this.style.background='var(--acc)'">멤버십 가입하기 ↗</a>
@@ -53,21 +45,18 @@
 
 <div id="drawer-bd" onclick="closeDrawer()"></div>
 <div id="drawer">
-  <div class="drawer-label">Navigation</div>
+  <div class="drawer-label">Menu</div>
   <ul>
-    {% if user.is_authenticated %}
-    <li><a href="/hari-chat/" onclick="closeDrawer()"><span style="color:var(--acc);font-weight:600;">하리와 대화하기</span></a></li>
-    {% else %}
-    <li><a href="#" onclick="closeDrawer(); openAuth('login'); return false;"><span style="color:var(--acc);font-weight:600;">하리와 대화하기</span></a></li>
-    {% endif %}
-    <!-- 사이드바 메뉴: 클릭 시 해당 전용 페이지로 이동 (/profile.html 페이지 등) -->
     <li><a href="/profile/" onclick="closeDrawer()"><span>Profile</span></a></li>
     <li><a href="/gallery/" onclick="closeDrawer()"><span>Gallery</span></a></li>
     <li><a href="/video/" onclick="closeDrawer()"><span>Video</span></a></li>
-    <li><a href="/news/" onclick="closeDrawer()"><span>News</span></a></li>
+    {% if user.is_authenticated %}
+    <li><a href="/hari-chat/" onclick="closeDrawer()"><span style="color:var(--acc);font-weight:600;">Chat 💬</span></a></li>
+    {% else %}
+    <li><a href="#" onclick="closeDrawer(); openAuth('login'); return false;"><span style="color:var(--acc);font-weight:600;">Chat 💬</span></a></li>
+    {% endif %}
     <li><a href="/membership/" onclick="closeDrawer()"><span>Membership</span></a></li>
     <li><a href="#s6" onclick="closeDrawer()"><span>Contact</span></a></li>
-    <li><a href="#s7" onclick="closeDrawer()"><span>SNS</span></a></li>
   </ul>
   <div class="drawer-sub-cta">
     <a href="/fanpage/">

--- a/backend/templates/frontend/includes/homepage/_s1_hero.html
+++ b/backend/templates/frontend/includes/homepage/_s1_hero.html
@@ -1,21 +1,278 @@
 {% load static %}
-<section id="s1" style="position: relative; height: 100vh; overflow: hidden; background-image: linear-gradient(rgba(0,0,0,0.15), rgba(0,0,0,0.4)), url('{% static 'images/hari_image5.png' %}'); background-size: cover; background-position: center; background-repeat: no-repeat;">
-  <div class="hero-logo-box" style="position: absolute; top: 100px; left: 50px; z-index: 10;">
-    <img src="{% static 'images/hari_logo_none.png' %}?v=3" alt="HARI" style="height: 140px; width: auto; filter: brightness(0) drop-shadow(0 0 20px rgba(255,255,255,0.3));">
-  </div>
-  
-  <div class="hero-inner" style="height: 100%; display: flex; flex-direction: column; justify-content: flex-end; align-items: flex-end; padding: 100px 50px;">
-    <!-- Removed Artist & Creative Box -->
+<section id="s1" style="position:relative;height:100vh;overflow:hidden;">
+
+  <!-- 슬라이드 (5개) -->
+  <div id="hero-slider" style="display:flex;width:500%;height:100%;transition:transform 0.7s cubic-bezier(0.77,0,0.175,1);">
+
+    <!-- Slide 1: Profile -->
+    <div class="hero-slide" data-bg="{% static 'images/hari_image6.png' %}">
+      <div class="hero-slide-label">
+        <span class="hero-slide-num">01</span>
+        <span class="hero-slide-name">Profile</span>
+        <a href="/profile/" class="hero-slide-cta">Discover &rarr;</a>
+      </div>
+    </div>
+
+    <!-- Slide 2: Gallery -->
+    <div class="hero-slide" data-bg="{% static 'images/hari_image2.png' %}">
+      <div class="hero-slide-label">
+        <span class="hero-slide-num">02</span>
+        <span class="hero-slide-name">Gallery</span>
+        <a href="/gallery/" class="hero-slide-cta">Discover &rarr;</a>
+      </div>
+    </div>
+
+    <!-- Slide 3: Video -->
+    <div class="hero-slide" data-bg="{% static 'images/hari_image5.png' %}">
+      <div class="hero-slide-label">
+        <span class="hero-slide-num">03</span>
+        <span class="hero-slide-name">Video</span>
+        <a href="/video/" class="hero-slide-cta">Discover &rarr;</a>
+      </div>
+    </div>
+
+    <!-- Slide 4: Chat -->
+    <div class="hero-slide" data-bg="{% static 'images/hari_image7.png' %}">
+      <div class="hero-slide-label">
+        <span class="hero-slide-num">04</span>
+        <span class="hero-slide-name">Chat</span>
+        <a href="/hari-chat/" class="hero-slide-cta">Discover &rarr;</a>
+      </div>
+    </div>
+
+    <!-- Slide 5: Membership -->
+    <div class="hero-slide" data-bg="{% static 'images/hari_image3.png' %}">
+      <div class="hero-slide-label">
+        <span class="hero-slide-num">05</span>
+        <span class="hero-slide-name">Membership</span>
+        <a href="/membership/" class="hero-slide-cta">Discover &rarr;</a>
+      </div>
+    </div>
+
   </div>
 
-  <div class="hero-bottom" style="font-family: var(--f-pixel);">
+  <!-- 로고 -->
+  <div style="position:absolute;top:100px;left:50px;z-index:10;pointer-events:none;">
+    <img src="{% static 'images/hari_logo_none.png' %}?v=3" alt="HARI" style="height:140px;width:auto;filter:brightness(0) invert(1) drop-shadow(0 0 20px rgba(255,255,255,0.3));">
+  </div>
+
+  <!-- 좌 화살표 -->
+  <button id="hero-prev" onclick="heroSlide(-1)" aria-label="이전">&#8249;</button>
+
+  <!-- 우 화살표 -->
+  <button id="hero-next" onclick="heroSlide(1)" aria-label="다음">&#8250;</button>
+
+  <!-- 슬라이드 번호 인디케이터 (우측) -->
+  <div id="hero-nav-panel">
+    <div id="hero-counter"><span id="hero-cur-num">01</span><span class="hero-counter-sep">/</span><span>05</span></div>
+    <ul id="hero-nav-list">
+      <li class="hero-nav-item on" onclick="heroGoTo(0)"><span class="hero-nav-idx">01</span><span class="hero-nav-title">Profile</span><span class="hero-nav-bar"></span></li>
+      <li class="hero-nav-item" onclick="heroGoTo(1)"><span class="hero-nav-idx">02</span><span class="hero-nav-title">Gallery</span><span class="hero-nav-bar"></span></li>
+      <li class="hero-nav-item" onclick="heroGoTo(2)"><span class="hero-nav-idx">03</span><span class="hero-nav-title">Video</span><span class="hero-nav-bar"></span></li>
+      <li class="hero-nav-item" onclick="heroGoTo(3)"><span class="hero-nav-idx">04</span><span class="hero-nav-title">Chat</span><span class="hero-nav-bar"></span></li>
+      <li class="hero-nav-item" onclick="heroGoTo(4)"><span class="hero-nav-idx">05</span><span class="hero-nav-title">Membership</span><span class="hero-nav-bar"></span></li>
+    </ul>
+  </div>
+
+  <!-- 하단 -->
+  <div class="hero-bottom" style="font-family:var(--f-pixel);z-index:10;">
     <div class="hero-bottom-text">Welcome to Hari's World</div>
     <div class="hero-scroll-hint">
       <div class="scroll-mouse"></div>
       <div class="scroll-line"></div>
       <div class="scroll-arrow"><span></span><span></span></div>
       Scroll
-ㅓ    </div>
+    </div>
   </div>
+
 </section>
 
+<style>
+.hero-slide {
+  flex: 0 0 20%;
+  width: 20%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  position: relative;
+}
+.hero-slide-label {
+  position: absolute;
+  bottom: 120px;
+  right: 60px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.4rem;
+}
+.hero-slide-num {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.2em;
+  color: rgba(255,255,255,0.55);
+}
+.hero-slide-name {
+  font-family: var(--f-sans, 'Inter', sans-serif);
+  font-size: clamp(2.5rem, 6vw, 5rem);
+  font-weight: 700;
+  color: #fff;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  text-shadow: 0 2px 20px rgba(0,0,0,0.3);
+}
+.hero-slide-cta {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.75);
+  text-decoration: none;
+  border-bottom: 0.5px solid rgba(255,255,255,0.4);
+  padding-bottom: 2px;
+  transition: color 0.2s, border-color 0.2s;
+}
+.hero-slide-cta:hover {
+  color: #fff;
+  border-color: #fff;
+}
+#hero-prev, #hero-next {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 20;
+  background: rgba(255,255,255,0.12);
+  border: 0.5px solid rgba(255,255,255,0.3);
+  color: #fff;
+  width: 48px;
+  height: 48px;
+  font-size: 1.6rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(6px);
+  transition: background 0.2s;
+}
+#hero-prev:hover, #hero-next:hover {
+  background: rgba(255,255,255,0.25);
+}
+#hero-prev { left: 28px; }
+#hero-next { right: 28px; }
+#hero-nav-panel {
+  position: absolute;
+  top: 110px;
+  right: 90px;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+#hero-counter {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.18em;
+  color: rgba(255,255,255,0.5);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+#hero-cur-num {
+  color: #fff;
+  font-size: 0.75rem;
+}
+.hero-counter-sep {
+  opacity: 0.4;
+}
+#hero-nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0;
+}
+.hero-nav-item {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.4rem 10px 0.4rem 0.5rem;
+  cursor: pointer;
+  transition: opacity 0.2s;
+  opacity: 0.35;
+  position: relative;
+}
+.hero-nav-item:hover { opacity: 0.75; }
+.hero-nav-item.on   { opacity: 1; }
+.hero-nav-idx {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.5rem;
+  letter-spacing: 0.15em;
+  color: rgba(255,255,255,0.55);
+}
+.hero-nav-title {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #fff;
+}
+/* 활성 슬라이드: 오른쪽 세로 바 */
+.hero-nav-bar {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2px;
+  height: 0;
+  background: #fff;
+  transition: height 0.3s;
+}
+.hero-nav-item.on .hero-nav-bar { height: 70%; }
+</style>
+
+<script>
+(function() {
+  // 배경 이미지 적용
+  document.querySelectorAll('.hero-slide').forEach(function(slide) {
+    var bg = slide.getAttribute('data-bg');
+    if (bg) {
+      slide.style.backgroundImage = 'linear-gradient(rgba(0,0,0,0.2),rgba(0,0,0,0.45)),url(' + bg + ')';
+    }
+  });
+
+  var cur = 0;
+  var total = 5;
+  var autoTimer;
+
+  function update() {
+    document.getElementById('hero-slider').style.transform = 'translateX(-' + (cur * 20) + '%)';
+    document.querySelectorAll('.hero-nav-item').forEach(function(d, i) {
+      d.classList.toggle('on', i === cur);
+    });
+    document.getElementById('hero-cur-num').textContent = String(cur + 1).padStart(2, '0');
+  }
+
+  window.heroSlide = function(dir) {
+    cur = (cur + dir + total) % total;
+    update();
+    resetAuto();
+  };
+
+  window.heroGoTo = function(idx) {
+    cur = idx;
+    update();
+    resetAuto();
+  };
+
+  function resetAuto() {
+    clearInterval(autoTimer);
+    autoTimer = setInterval(function() { heroSlide(1); }, 5000);
+  }
+
+  resetAuto();
+})();
+</script>

--- a/backend/templates/frontend/includes/homepage/_s4_video.html
+++ b/backend/templates/frontend/includes/homepage/_s4_video.html
@@ -146,7 +146,7 @@
 <section id="s4">
   <div class="s4-header">
     <h2 class="s4-title">VIDEOS</h2>
-    <a class="s4-more" href="https://www.youtube.com/@Hari-o5m2r" target="_blank">채널 보기 ↗</a>
+    <a class="s4-more" href="/video/">모두 보기 ↗</a>
   </div>
 
   <!-- 전달해주신 코드 원형 적용 -->

--- a/backend/templates/frontend/includes/homepage/_s5_news.html
+++ b/backend/templates/frontend/includes/homepage/_s5_news.html
@@ -2,7 +2,7 @@
 
 <section id="s5">
   <div class="sec-header">
-    <div><div class="sec-tag">04 — News &amp; Schedule</div><h2 class="sec-title">NEWS</h2></div>
+    <div><div class="sec-tag">04 — Schedule</div><h2 class="sec-title">SCHEDULE</h2></div>
     <a class="sec-more" href="/news/">모두 보기 →</a>
   </div>
   <div class="news-grid">

--- a/backend/templates/frontend/includes/homepage/_s8_footer.html
+++ b/backend/templates/frontend/includes/homepage/_s8_footer.html
@@ -13,8 +13,6 @@
       <li><a href="#s2">Profile</a></li>
       <li><a href="#s3">Gallery</a></li>
       <li><a href="/video/">Video</a></li>
-      <li><a href="#s-sub">Membership</a></li>
-      <li><a href="#s5">News</a></li>
       <li><a href="#s6">Contact</a></li>
     </ul>
   </div>


### PR DESCRIPTION
- 히어로 섹션을 전체화면 슬라이더로 교체 (Profile/Gallery/Video/Chat/Membership 5슬라이드)
- 슬라이더 우측 번호 인디케이터 및 현재/전체 카운터(01/05) 추가
- 메인 페이지에서 s6_membership 섹션 및 s5_news 섹션 제거
- 내비바 섹션 앵커 링크 제거, CTA(하리와 대화하기/마이페이지/멤버십) 만 유지
- 모바일 드로어 메뉴 슬라이더 구성과 동일하게 재정리 (Contact 추가)
- 내비바 및 푸터에서 SNS/Membership/News 불필요 항목 제거
- 팬페이지 사이드바에서 멤버십 관리 항목 제거
- Video 섹션 "채널 보기" → "모두 보기" 변경 및 /video/ 링크 연결