### PR TITLE
feat(frontend): 멤버십 플랜 개편 및 비디오·푸터 UI 개선

### DIFF
--- a/backend/templates/frontend/includes/homepage/_s8_footer.html
+++ b/backend/templates/frontend/includes/homepage/_s8_footer.html
@@ -10,9 +10,11 @@
   <div class="ft-nav-area">
     <div class="ft-nav-lbl">Navigation</div>
     <ul class="ft-nav-list">
-      <li><a href="#s2">Profile</a></li>
-      <li><a href="#s3">Gallery</a></li>
+      <li><a href="/profile/">Profile</a></li>
+      <li><a href="/gallery/">Gallery</a></li>
       <li><a href="/video/">Video</a></li>
+      <li><a href="/hari-chat/">Chat</a></li>
+      <li><a href="/membership/">Membership</a></li>
       <li><a href="#s6">Contact</a></li>
     </ul>
   </div>

--- a/backend/templates/frontend/membership.html
+++ b/backend/templates/frontend/membership.html
@@ -119,9 +119,9 @@
     .plan-card.selected .plan-header::after { opacity: 1; }
 
     /* Tier Colors */
-    .header-basic { background: linear-gradient(135deg, #1e3c72, #2a5298); }
-    .header-standard { background: linear-gradient(135deg, #6a11cb, #2575fc); }
-    .header-premium { background: linear-gradient(135deg, #e50914, #ff5f6d); }
+    .header-fan    { background: linear-gradient(135deg, #1e3c72, #2a5298); }
+    .header-fanplus { background: linear-gradient(135deg, #6a11cb, #2575fc); }
+    .header-bori   { background: linear-gradient(135deg, #e50914, #ff5f6d); }
 
     .plan-body {
       padding: 20px 15px;
@@ -218,108 +218,132 @@
     <h1 class="main-title">원하는 멤버십을 선택하세요</h1>
 
     <div class="plans-wrapper">
-      
-      <!-- Basic -->
-      <div class="plan-card" onclick="selectPlan(this, 'basic')">
-        <div class="plan-header header-basic">
-          광고형 스탠다드
-          <div style="font-size: 13px; font-weight: 400; margin-top: 4px;">1080p</div>
+
+      <!-- FAN -->
+      <div class="plan-card" onclick="selectPlan(this, 'fan')">
+        <div class="plan-header header-fan">
+          FAN
+          <div style="font-size: 13px; font-weight: 400; margin-top: 4px;">베이직 플랜</div>
         </div>
         <div class="plan-body">
           <div class="feature-item">
             <div class="feature-label">월 요금</div>
-            <div class="feature-val">₩109,900</div>
+            <div class="feature-val">₩39,900</div>
+          </div>
+          <div class="feature-item">
+            <div class="feature-label">연간 요금</div>
+            <div class="feature-val">₩399,000 <span style="font-size:11px;color:var(--text-dim);">(2개월 무료)</span></div>
           </div>
           <div class="plan-divider"></div>
           <div class="feature-item">
-            <div class="feature-label">화질 및 음질</div>
-            <div class="feature-val">좋음</div>
+            <div class="feature-label">하리와 대화</div>
+            <div class="feature-val">월 300회</div>
           </div>
           <div class="feature-item">
-            <div class="feature-label">해상도</div>
-            <div class="feature-val">1080p (Full HD)</div>
+            <div class="feature-label">마이페이지</div>
+            <div class="feature-val">사용 가능</div>
           </div>
           <div class="feature-item">
-            <div class="feature-label">지원 디바이스</div>
-            <div class="feature-val">TV, 컴퓨터, 스마트폰, 태블릿</div>
+            <div class="feature-label">갤러리 · 동영상</div>
+            <div class="feature-val">시청 가능</div>
           </div>
           <div class="feature-item">
-            <div class="feature-label">가구 구성원 간 동시 시청 수</div>
-            <div class="feature-val">2</div>
+            <div class="feature-label">마이페이지 구매 할인</div>
+            <div class="feature-val">—</div>
           </div>
           <div class="feature-item">
-            <div class="feature-label">광고</div>
-            <div class="feature-val">일부 콘텐츠 광고</div>
+            <div class="feature-label">하리 롤플레잉 시뮬레이션</div>
+            <div class="feature-val" style="color:var(--text-dim);">—</div>
+          </div>
+          <div class="feature-item">
+            <div class="feature-label">연간 구독 혜택</div>
+            <div class="feature-val">마지막 2개월 무료</div>
           </div>
         </div>
       </div>
 
-      <!-- Standard -->
-      <div class="plan-card selected" onclick="selectPlan(this, 'standard')">
-        <div class="plan-header header-standard">
-          스탠다드
-          <div style="font-size: 13px; font-weight: 400; margin-top: 4px;">1080p</div>
+      <!-- FAN+ -->
+      <div class="plan-card selected" onclick="selectPlan(this, 'fanplus')">
+        <div class="plan-header header-fanplus">
+          FAN+
+          <div style="font-size: 13px; font-weight: 400; margin-top: 4px;">스탠다드 플랜</div>
         </div>
         <div class="plan-body">
           <div class="feature-item">
             <div class="feature-label">월 요금</div>
-            <div class="feature-val">₩209,900</div>
+            <div class="feature-val">₩69,900</div>
+          </div>
+          <div class="feature-item">
+            <div class="feature-label">연간 요금</div>
+            <div class="feature-val">₩699,000 <span style="font-size:11px;color:var(--text-dim);">(2개월 무료)</span></div>
           </div>
           <div class="plan-divider"></div>
           <div class="feature-item">
-            <div class="feature-label">화질 및 음질</div>
-            <div class="feature-val">좋음</div>
+            <div class="feature-label">하리와 대화</div>
+            <div class="feature-val">월 600회</div>
           </div>
           <div class="feature-item">
-            <div class="feature-label">해상도</div>
-            <div class="feature-val">1080p (Full HD)</div>
+            <div class="feature-label">마이페이지</div>
+            <div class="feature-val">사용 가능</div>
           </div>
           <div class="feature-item">
-            <div class="feature-label">지원 디바이스</div>
-            <div class="feature-val">TV, 컴퓨터, 스마트폰, 태블릿</div>
+            <div class="feature-label">갤러리 · 동영상</div>
+            <div class="feature-val">시청 가능</div>
           </div>
           <div class="feature-item">
-            <div class="feature-label">가구 구성원 간 동시 시청 수</div>
-            <div class="feature-val">2</div>
+            <div class="feature-label">마이페이지 구매 할인</div>
+            <div class="feature-val">10% 할인</div>
           </div>
           <div class="feature-item">
-            <div class="feature-label">광고</div>
-            <div class="feature-val">광고 없음</div>
+            <div class="feature-label">하리 롤플레잉 시뮬레이션</div>
+            <div class="feature-val" style="color:var(--text-dim);">—</div>
+          </div>
+          <div class="feature-item">
+            <div class="feature-label">연간 구독 혜택</div>
+            <div class="feature-val">마지막 2개월 무료</div>
           </div>
         </div>
       </div>
 
-      <!-- Premium -->
-      <div class="plan-card" onclick="selectPlan(this, 'premium')">
-        <div class="plan-header header-premium">
-          프리미엄
-          <div style="font-size: 13px; font-weight: 400; margin-top: 4px;">4K + HDR</div>
+      <!-- BORI -->
+      <div class="plan-card" onclick="selectPlan(this, 'bori')">
+        <div class="plan-header header-bori">
+          BORI
+          <div style="font-size: 13px; font-weight: 400; margin-top: 4px;">프리미엄 플랜</div>
         </div>
         <div class="plan-body">
           <div class="feature-item">
             <div class="feature-label">월 요금</div>
-            <div class="feature-val">₩309,900</div>
+            <div class="feature-val">₩99,900</div>
+          </div>
+          <div class="feature-item">
+            <div class="feature-label">연간 요금</div>
+            <div class="feature-val">₩899,100 <span style="font-size:11px;color:var(--text-dim);">(3개월 무료)</span></div>
           </div>
           <div class="plan-divider"></div>
           <div class="feature-item">
-            <div class="feature-label">화질 및 음질</div>
-            <div class="feature-val">가장 좋음</div>
+            <div class="feature-label">하리와 대화</div>
+            <div class="feature-val">월 1000회</div>
           </div>
           <div class="feature-item">
-            <div class="feature-label">해상도</div>
-            <div class="feature-val">4K (Ultra HD) + HDR</div>
+            <div class="feature-label">마이페이지</div>
+            <div class="feature-val">사용 가능</div>
           </div>
           <div class="feature-item">
-            <div class="feature-label">지원 디바이스</div>
-            <div class="feature-val">TV, 컴퓨터, 스마트폰, 태블릿</div>
+            <div class="feature-label">갤러리 · 동영상</div>
+            <div class="feature-val">시청 가능</div>
           </div>
           <div class="feature-item">
-            <div class="feature-label">가구 구성원 간 동시 시청 수</div>
-            <div class="feature-val">4</div>
+            <div class="feature-label">마이페이지 구매 할인</div>
+            <div class="feature-val">20% 할인</div>
           </div>
           <div class="feature-item">
-            <div class="feature-label">광고</div>
-            <div class="feature-val">광고 없음</div>
+            <div class="feature-label">하리 롤플레잉 시뮬레이션</div>
+            <div class="feature-val">가능 ✦</div>
+          </div>
+          <div class="feature-item">
+            <div class="feature-label">연간 구독 혜택</div>
+            <div class="feature-val">마지막 3개월 무료</div>
           </div>
         </div>
       </div>
@@ -327,8 +351,8 @@
     </div><!-- /.plans-wrapper -->
 
     <div class="footer-disclaimer">
-      <p style="margin-bottom: 12px;">광고형 멤버십으로 대부분의 Hari 시리즈와 영화를 즐길 수 있지만, 라이선스 제한으로 시청할 수 없는 콘텐츠도 일부 있습니다. <a href="#">광고형 멤버십에 대해 자세히 알아보세요.</a></p>
-      <p>가구 구성원 외의 사용자라면 별도의 계정을 생성해 멤버십에 가입하거나 프리미엄 혹은 스탠다드 멤버십의 추가 회원이 될 수 있습니다. <a href="#">자세히 보기.</a></p>
+      <p style="margin-bottom: 12px;">모든 멤버십은 유료 구독 서비스입니다. 연간 구독 시 명시된 무료 기간 혜택이 자동 적용됩니다.</p>
+      <p>멤버십 관련 문의는 Contact 페이지를 통해 접수해 주세요.</p>
     </div>
 
   </div><!-- /.container -->
@@ -341,7 +365,7 @@
   </div>
 
   <script>
-    let selectedTier = 'standard';
+    let selectedTier = 'fanplus';
 
     function selectPlan(el, tier) {
       document.querySelectorAll('.plan-card').forEach(c => c.classList.remove('selected'));

--- a/backend/templates/frontend/video.html
+++ b/backend/templates/frontend/video.html
@@ -103,129 +103,54 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;over
 /* ── VIDEO GRID ── */
 .vd-grid{
   padding:2.5rem;
-  display:grid;
-  grid-template-columns:repeat(auto-fill,minmax(260px,1fr));
-  gap:1.5rem;
+  overflow:hidden;
+}
+.vd-grid-inner{
+  display:flex;
+  flex-wrap:wrap;
+  gap:24px;
 }
 
-/* ── VIDEO CARD ── */
-.vd-card{
-  border:.5px solid var(--bdr);overflow:hidden;
-  transition:border-color .25s,transform .25s,box-shadow .25s;
-  cursor:pointer;
-  animation:cardIn .5s ease both;
+/* ── YT CARD (메인과 동일) ── */
+.yt-card{
+  display:flex;flex-direction:column;align-items:flex-start;
+  max-width:340px;width:100%;margin:0;
 }
-.vd-card:hover{
-  border-color:var(--acc);
-  transform:translateY(-4px);
-  box-shadow:0 12px 40px rgba(255,123,138,0.15);
+.yt-thumb-wrap{
+  position:relative;width:100%;padding-bottom:177.78%;
+  background:#000;border-radius:4px;overflow:hidden;
+  box-shadow:0 10px 20px rgba(0,0,0,0.1);
 }
-@keyframes cardIn{from{opacity:0;transform:translateY(20px)}to{opacity:1;transform:translateY(0)}}
-.vd-card:nth-child(1){animation-delay:.05s}
-.vd-card:nth-child(2){animation-delay:.1s}
-.vd-card:nth-child(3){animation-delay:.15s}
-.vd-card:nth-child(4){animation-delay:.2s}
-.vd-card:nth-child(5){animation-delay:.25s}
-.vd-card:nth-child(6){animation-delay:.3s}
-.vd-card[data-type="full"]{grid-column:span 2;}
-
-/* 세로형 Shorts */
-.vd-frame-shorts{position:relative;padding-bottom:177.78%;height:0;overflow:hidden;background:#0a0a0a;}
-.vd-frame-shorts img{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;}
-.vd-frame-shorts .vd-play-overlay{
-  position:absolute;inset:0;display:flex;align-items:center;justify-content:center;
-  background:rgba(0,0,0,0.25);transition:background .2s;
+.yt-thumb-wrap iframe{
+  position:absolute;top:0;left:0;width:100%;height:100%;border:none;
 }
-.vd-card:hover .vd-play-overlay{background:rgba(0,0,0,0.4);}
-.vd-play-btn{
-  width:52px;height:52px;border-radius:50%;
-  background:rgba(255,255,255,0.95);
-  display:flex;align-items:center;justify-content:center;
-  transition:transform .2s,background .2s;
+.yt-shorts-badge{
+  position:absolute;bottom:10px;right:10px;
+  background:#ff0000;color:#fff;font-size:.7rem;font-weight:700;
+  padding:2px 6px;border-radius:4px;
+  display:flex;align-items:center;font-family:sans-serif;
+  pointer-events:none;
 }
-.vd-card:hover .vd-play-btn{transform:scale(1.1);background:#fff;}
-.vd-play-btn svg{width:20px;height:20px;fill:var(--acc);margin-left:2px;}
-
-/* 가로형 Full */
-.vd-frame-full{position:relative;padding-bottom:56.25%;height:0;overflow:hidden;background:#0a0a0a;}
-.vd-frame-full img{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;}
-.vd-frame-full .vd-play-overlay{
-  position:absolute;inset:0;display:flex;align-items:center;justify-content:center;
-  background:rgba(0,0,0,0.25);transition:background .2s;
+.yt-info{text-align:left;margin-top:1rem;width:100%;padding:0 4px;}
+.yt-title{font-family:var(--f-neo);font-size:1.05rem;font-weight:500;color:#222;line-height:1.3;margin-bottom:.4rem;}
+.yt-meta span{font-family:var(--f-pixel);font-size:.75rem;color:var(--dim);display:inline-block;margin-bottom:.8rem;}
+.yt-link{
+  display:inline-flex;align-items:center;gap:6px;
+  font-size:.8rem;color:#555;text-decoration:none;font-weight:500;transition:color .2s;
 }
-.vd-card:hover .vd-frame-full .vd-play-overlay{background:rgba(0,0,0,0.4);}
-
-.vd-badge{
-  position:absolute;top:.6rem;left:.6rem;
-  font-family:'DM Mono',monospace;font-size:.46rem;
-  letter-spacing:.12em;text-transform:uppercase;
-  padding:3px 9px;pointer-events:none;z-index:2;
-}
-.vd-badge.shorts{background:var(--acc);color:#fff;}
-.vd-badge.full{background:var(--ink);color:#fff;}
-
-.vd-info{padding:1.1rem 1.2rem;}
-.vd-info-title{font-size:.88rem;color:var(--ink);line-height:1.5;margin-bottom:.3rem;font-weight:400;}
-.vd-info-meta{font-family:'DM Mono',monospace;font-size:.5rem;letter-spacing:.1em;color:var(--dim);margin-bottom:.7rem;}
-.vd-info-link{
-  font-family:'DM Mono',monospace;font-size:.52rem;letter-spacing:.1em;
-  text-transform:uppercase;color:var(--acc);text-decoration:none;
-  display:inline-flex;align-items:center;gap:.3rem;
-  border-bottom:.5px solid var(--acc);padding-bottom:1px;transition:color .2s;
-}
-.vd-info-link:hover{color:var(--ink);}
+.yt-link:hover{color:#ff7b8a;}
 
 /* ── EMPTY STATE ── */
 .vd-empty{
-  grid-column:1/-1;padding:5rem 2.5rem;
-  text-align:center;color:var(--dim);display:none;
+  padding:5rem 2.5rem;text-align:center;color:var(--dim);display:none;
 }
 .vd-empty p{font-family:'DM Mono',monospace;font-size:.7rem;letter-spacing:.15em;text-transform:uppercase;margin-bottom:1rem;}
 .vd-empty a{font-family:'DM Mono',monospace;font-size:.6rem;letter-spacing:.14em;text-transform:uppercase;color:var(--acc);text-decoration:none;border-bottom:.5px solid var(--acc);}
 
-/* ── YT MODAL ── */
-#vd-modal-overlay{
-  position:fixed;inset:0;z-index:600;
-  background:rgba(42,36,32,0.85);
-  backdrop-filter:blur(8px);
-  display:flex;align-items:center;justify-content:center;
-  opacity:0;pointer-events:none;
-  transition:opacity .3s;
+@media(max-width:768px){
+  .vd-grid-inner{justify-content:center;}
 }
-#vd-modal-overlay.show{opacity:1;pointer-events:all;}
-#vd-modal-box{
-  position:relative;
-  transform:translateY(24px) scale(.97);
-  transition:transform .38s cubic-bezier(.77,0,.18,1);
-}
-#vd-modal-overlay.show #vd-modal-box{transform:translateY(0) scale(1);}
-#vd-modal-iframe-wrap{
-  position:relative;width:100%;
-  background:#000;
-}
-#vd-modal-iframe-wrap iframe{
-  position:absolute;inset:0;width:100%;height:100%;border:none;
-}
-#vd-modal-info{
-  padding:.85rem 1rem .7rem;
-  background:var(--s7-bg);
-  display:flex;align-items:center;justify-content:space-between;gap:1rem;
-}
-#vd-modal-title{font-size:.86rem;color:rgba(255,245,246,0.9);line-height:1.5;flex:1;}
-#vd-modal-yt-link{
-  font-family:'DM Mono',monospace;font-size:.52rem;letter-spacing:.1em;
-  text-transform:uppercase;color:var(--acc);text-decoration:none;
-  border-bottom:.5px solid var(--acc);padding-bottom:1px;white-space:nowrap;transition:color .2s;
-}
-#vd-modal-yt-link:hover{color:#fff;}
-#vd-modal-close{
-  flex-shrink:0;
-  background:transparent;border:.5px solid rgba(255,245,246,.22);
-  color:rgba(255,245,246,.9);font-family:'DM Mono',monospace;
-  font-size:.56rem;letter-spacing:.12em;text-transform:uppercase;
-  padding:5px 14px;cursor:pointer;transition:background .2s;white-space:nowrap;
-}
-#vd-modal-close:hover{background:var(--acc);border-color:var(--acc);}
+
 
 /* ── FOOTER ── */
 .vd-footer{
@@ -301,57 +226,56 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;over
 
 <!-- VIDEO GRID -->
 <div class="vd-grid" id="vd-grid">
+  <div class="vd-grid-inner">
 
-  <!-- Shorts 1 -->
-  <div class="vd-card" data-type="shorts" onclick="openModal('7Ytd-ZDlO0c','&lt;테크뉴스&gt; 초파리 뇌의 비밀','https://www.youtube.com/shorts/7Ytd-ZDlO0c',true)">
-    <div class="vd-frame-shorts" style="position:relative;">
-      <img src="https://img.youtube.com/vi/7Ytd-ZDlO0c/hqdefault.jpg" alt="초파리 뇌의 비밀" loading="lazy">
-      <span class="vd-badge shorts">▶ Shorts</span>
-      <div class="vd-play-overlay">
-        <div class="vd-play-btn">
-          <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
-        </div>
+    <!-- 영상 1 -->
+    <div class="yt-card">
+      <div class="yt-thumb-wrap">
+        <iframe src="https://www.youtube.com/embed/7Ytd-ZDlO0c?mute=1&loop=1&playlist=7Ytd-ZDlO0c"
+          title="YouTube Shorts" frameborder="0"
+          referrerpolicy="strict-origin-when-cross-origin"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen>
+        </iframe>
+        <span class="yt-shorts-badge">▶ Shorts</span>
+      </div>
+      <div class="yt-info">
+        <div class="yt-title">&lt;테크뉴스&gt; 초파리 뇌의 비밀</div>
+        <div class="yt-meta"><span>최근 소식</span></div>
+        <a class="yt-link" href="https://www.youtube.com/shorts/7Ytd-ZDlO0c" target="_blank" rel="noopener">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg>
+          YouTube 앱에서 보기 ↗
+        </a>
       </div>
     </div>
-    <div class="vd-info">
-      <div class="vd-info-title">&lt;테크뉴스&gt; 초파리 뇌의 비밀</div>
-      <div class="vd-info-meta">최근 소식 · Shorts</div>
-      <a class="vd-info-link" href="https://www.youtube.com/shorts/7Ytd-ZDlO0c" target="_blank" rel="noopener" onclick="event.stopPropagation()">
-        <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"/></svg>
-        YouTube에서 보기
-      </a>
-    </div>
-  </div>
 
-  <!-- Shorts 2 -->
-  <div class="vd-card" data-type="shorts" onclick="openModal('LFBHDLvL2Yw','&lt;테크뉴스&gt; 구글 Stitch','https://www.youtube.com/shorts/LFBHDLvL2Yw',true)">
-    <div class="vd-frame-shorts" style="position:relative;">
-      <img src="https://img.youtube.com/vi/LFBHDLvL2Yw/hqdefault.jpg" alt="구글 Stitch" loading="lazy">
-      <span class="vd-badge shorts">▶ Shorts</span>
-      <div class="vd-play-overlay">
-        <div class="vd-play-btn">
-          <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
-        </div>
+    <!-- 영상 2 -->
+    <div class="yt-card">
+      <div class="yt-thumb-wrap">
+        <iframe src="https://www.youtube.com/embed/LFBHDLvL2Yw?mute=1&loop=1&playlist=LFBHDLvL2Yw"
+          title="YouTube Shorts" frameborder="0"
+          referrerpolicy="strict-origin-when-cross-origin"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen>
+        </iframe>
+        <span class="yt-shorts-badge">▶ Shorts</span>
+      </div>
+      <div class="yt-info">
+        <div class="yt-title">&lt;테크뉴스&gt; 구글 Stitch</div>
+        <div class="yt-meta"><span>최근 소식</span></div>
+        <a class="yt-link" href="https://www.youtube.com/shorts/LFBHDLvL2Yw" target="_blank" rel="noopener">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg>
+          YouTube 앱에서 보기 ↗
+        </a>
       </div>
     </div>
-    <div class="vd-info">
-      <div class="vd-info-title">&lt;테크뉴스&gt; 구글 Stitch</div>
-      <div class="vd-info-meta">최근 소식 · Shorts</div>
-      <a class="vd-info-link" href="https://www.youtube.com/shorts/LFBHDLvL2Yw" target="_blank" rel="noopener" onclick="event.stopPropagation()">
-        <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"/></svg>
-        YouTube에서 보기
-      </a>
+
+    <div class="vd-empty" id="vd-empty">
+      <p>해당 카테고리에 영상이 없어요</p>
+      <a href="https://www.youtube.com/@Hari-o5m2r" target="_blank" rel="noopener">YouTube 채널 방문하기 ↗</a>
     </div>
+
   </div>
-
-
-
-  <!-- Empty state (보이는 카드가 없을 때) -->
-  <div class="vd-empty" id="vd-empty">
-    <p>해당 카테고리에 영상이 없어요</p>
-    <a href="https://www.youtube.com/@Hari-o5m2r" target="_blank" rel="noopener">YouTube 채널 방문하기 ↗</a>
-  </div>
-
 </div>
 
 <!-- FOOTER -->
@@ -364,110 +288,9 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;over
   </div>
 </footer>
 
-<!-- YT MODAL -->
-<div id="vd-modal-overlay" onclick="if(event.target===this)closeModal()">
-  <div id="vd-modal-box">
-    <div id="vd-modal-iframe-wrap">
-      <iframe id="vd-modal-iframe" src="" allowfullscreen
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture">
-      </iframe>
-    </div>
-    <div id="vd-modal-info">
-      <div id="vd-modal-title"></div>
-      <a id="vd-modal-yt-link" href="#" target="_blank" rel="noopener">채널 방문 ↗</a>
-      <button id="vd-modal-close" onclick="closeModal()">닫기 ✕</button>
-    </div>
-  </div>
-</div>
-
 <script>
-/* ── Filter ── */
-let currentFilter = 'all';
-
-function filterVideos(type, btn) {
-  currentFilter = type;
-
-  // 모든 버튼 off
-  document.querySelectorAll('.vd-filter-btn').forEach(b => b.classList.remove('on'));
-  // 클릭된 버튼 그룹의 같은 타입 버튼들 on
-  document.querySelectorAll('.vd-filter-btn').forEach(b => {
-    if ((b.textContent.trim().toLowerCase() === type) ||
-        (type === 'all' && b.textContent.trim() === 'All')) {
-      b.classList.add('on');
-    }
-  });
-  if (type === 'all') {
-    document.querySelectorAll('.vd-filter-btn').forEach(b => {
-      if (b.textContent.trim() === 'All') b.classList.add('on');
-    });
-  }
-
-  let visible = 0;
-  document.querySelectorAll('.vd-card').forEach(card => {
-    const show = (type === 'all' || card.dataset.type === type);
-    card.style.display = show ? '' : 'none';
-    if (show) visible++;
-  });
-
-  const empty = document.getElementById('vd-empty');
-  if (empty) empty.style.display = visible === 0 ? 'block' : 'none';
-
-  // span 컬럼 조정 — 필터 시 full 카드 span 유지
-  updateSpan();
-}
-
-function updateSpan() {
-  document.querySelectorAll('.vd-card[data-type="full"]').forEach(card => {
-    card.style.gridColumn = card.style.display === 'none' ? '' : 'span 2';
-  });
-}
-
-/* ── Modal ── */
-let currentYtUrl = '#';
-
-function openModal(vid, title, ytUrl, isShorts) {
-  const overlay = document.getElementById('vd-modal-overlay');
-  const iframe  = document.getElementById('vd-modal-iframe');
-  const titleEl = document.getElementById('vd-modal-title');
-  const ytLink  = document.getElementById('vd-modal-yt-link');
-  const box     = document.getElementById('vd-modal-box');
-  const wrap    = document.getElementById('vd-modal-iframe-wrap');
-
-  currentYtUrl = ytUrl;
-  ytLink.href  = ytUrl;
-
-  const decoded = title.replace(/&lt;/g,'<').replace(/&gt;/g,'>');
-  titleEl.textContent = decoded;
-
-  if (isShorts) {
-    box.style.maxWidth     = '380px';
-    wrap.style.aspectRatio = '9/16';
-    iframe.src = `https://www.youtube.com/embed/${vid}?rel=0&autoplay=1&loop=1&playlist=${vid}`;
-  } else {
-    box.style.maxWidth     = '900px';
-    wrap.style.aspectRatio = '16/9';
-    iframe.src = `https://www.youtube.com/embed/${vid}?rel=0&autoplay=1`;
-  }
-
-  overlay.classList.add('show');
-  document.body.style.overflow = 'hidden';
-}
-
-function closeModal() {
-  const overlay = document.getElementById('vd-modal-overlay');
-  const iframe  = document.getElementById('vd-modal-iframe');
-  overlay.classList.remove('show');
-  document.body.style.overflow = '';
-  setTimeout(() => { iframe.src = ''; }, 350);
-}
-
-document.addEventListener('keydown', e => {
-  if (e.key === 'Escape') closeModal();
-});
-
-/* ── video count ── */
 document.addEventListener('DOMContentLoaded', () => {
-  const total = document.querySelectorAll('.vd-card').length;
+  const total = document.querySelectorAll('.yt-card').length;
   const el = document.getElementById('video-total-count');
   if (el) el.textContent = total;
 });


### PR DESCRIPTION
- 멤버십 플랜을 FAN / FAN+ / BORI 3단계로 전면 개편
  - 각 플랜별 월 요금(₩39,900 / ₩69,900 / ₩99,900) 및 연간 요금 추가
  - 하리와 대화 횟수, 마이페이지 할인, 연간 무료 혜택 항목 구성
  - BORI 플랜 전용 하리 롤플레잉 시뮬레이션 기능 추가
- video.html 영상 카드를 메인과 동일한 iframe 임베드 방식으로 변경
- footer 내비게이션을 사이드바와 동일하게 재정리 (Chat, Membership 추가)