### PR TITLE
feat(frontend): 미디어 쿼리 통일 및 컨테이너 쿼리 시스템 적용

### DIFF
--- a/backend/templates/frontend/chat.html
+++ b/backend/templates/frontend/chat.html
@@ -1030,24 +1030,46 @@ html, body {
 
 
 /* ═══════════════════════════════════════
-   RESPONSIVE
+   CONTAINER QUERIES — chat-main 기준
    ═══════════════════════════════════════ */
-@media (max-width: 1200px) {
+.chat-main { container-type: inline-size; container-name: chat-main; }
+
+/* chat-main 너비 600px 이하: 버블 넓게 */
+@container chat-main (max-width: 600px) {
+  .msg-content { max-width: 90%; }
+  .chat-container { padding: 10px 12px; }
+}
+/* chat-main 너비 400px 이하: 모바일 밀집 */
+@container chat-main (max-width: 400px) {
+  .msg-bubble { font-size: 0.88rem; padding: 9px 13px; }
+  .input-area { padding: 6px 10px; }
+}
+
+/* ═══════════════════════════════════════
+   MEDIA QUERIES
+   ═══════════════════════════════════════ */
+/* 1280px: 우측 사이드바 숨김 */
+@media (max-width: 1280px) {
   .sidebar-right { display: none; }
 }
-
+/* 1024px: 레이아웃 풀너비 */
 @media (max-width: 1024px) {
   .app-container { width: 100vw; }
+  .sidebar-left { width: 260px; }
 }
-
+/* 768px: 태블릿 — 좌측 사이드바 숨김 */
 @media (max-width: 768px) {
   .sidebar-left { display: none; }
   .chat-main { width: 100%; }
-  .msg-content { max-width: 85%; }
   .header { padding: 12px 16px; }
-  .chat-container { padding: 12px; }
-  .input-area { padding: 8px 12px; }
   .quick-replies { padding: 8px 12px; }
+}
+/* 480px: 모바일 */
+@media (max-width: 480px) {
+  .header { padding: 10px 14px; }
+  .header-profile .profile-name { font-size: 0.9rem; }
+  .input-area { padding: 6px 10px; }
+  .quick-reply-btn { font-size: 0.72rem; padding: 6px 12px; }
 }
 </style>
 </head>

--- a/backend/templates/frontend/fanpage.html
+++ b/backend/templates/frontend/fanpage.html
@@ -234,12 +234,34 @@ button{cursor:pointer;font-family:inherit;}
 #toast{position:fixed;bottom:2rem;left:50%;transform:translateX(-50%) translateY(80px);background:var(--ink);color:#fff;font-family:'NeoDunggeunmo',monospace;font-size:.62rem;letter-spacing:.1em;padding:.68rem 1.5rem;opacity:0;transition:all .3s;z-index:600;pointer-events:none;white-space:nowrap;border-radius:25px;box-shadow:0 4px 20px rgba(42,36,32,0.25);}
 #toast.on{opacity:1;transform:translateX(-50%) translateY(0);}
 
+/* CONTAINER QUERIES — #main 기준 */
+#main { container-type: inline-size; container-name: fp-main; }
+
+/* 카드 그리드: main 너비 700px 이하 */
+@container fp-main (max-width: 700px) {
+  .g2,.info-grid,.frow{ grid-template-columns:1fr; }
+  .g3{ grid-template-columns:1fr 1fr; }
+  .stat-grid{ grid-template-columns:repeat(2,1fr); }
+  .shop-grid{ grid-template-columns:repeat(2,1fr); }
+}
+/* main 너비 420px 이하: 1컬럼 */
+@container fp-main (max-width: 420px) {
+  .g3,.stat-grid,.shop-grid{ grid-template-columns:1fr; }
+  .pg{ padding:1.2rem 1rem; }
+}
+
+/* MEDIA QUERIES */
+@media(max-width:1024px){
+  #sidebar{ width:200px; }
+  --sw: 200px;
+}
 @media(max-width:800px){
-  #sidebar{display:none;}
-  .stat-grid{grid-template-columns:repeat(2,1fr);}
-  .shop-grid{grid-template-columns:repeat(2,1fr);}
-  .g2,.info-grid,.frow{grid-template-columns:1fr;}
-  .g3{grid-template-columns:1fr 1fr;}
+  #sidebar{ display:none; }
+}
+@media(max-width:480px){
+  #topbar{ padding:0 1rem 0 0; }
+  .tb-pts-box{ display:none; }
+  .pg-title{ font-size:1.8rem; }
 }
 </style>
 </head>

--- a/backend/templates/frontend/gallery.html
+++ b/backend/templates/frontend/gallery.html
@@ -65,6 +65,13 @@ body{background:var(--bg);color:var(--ink);overflow-x:hidden;}
 #lb-next{right:1rem;}
 #lb-info{position:absolute;bottom:1.5rem;left:50%;transform:translateX(-50%);font-family:'DM Mono',monospace;font-size:.55rem;letter-spacing:.16em;color:rgba(255,255,255,0.5);}
 
+/* CONTAINER QUERY — 갤러리 그리드 기준 */
+.gl-body { container-type: inline-size; container-name: gl-body; }
+@container gl-body (max-width: 900px) { .gl-grid { columns: 3; } }
+@container gl-body (max-width: 600px) { .gl-grid { columns: 2; padding: 1.5rem; } }
+@container gl-body (max-width: 360px) { .gl-grid { columns: 1; } }
+
+/* MEDIA QUERIES */
 @media(max-width:1200px){.gl-grid{columns:3;}}
 @media(max-width:768px){.gl-grid{columns:2;padding:1.5rem;}.gl-header{flex-direction:column;gap:1.5rem;align-items:flex-start;}.gl-filter-group{flex-wrap:wrap;}}
 @media(max-width:480px){.gl-grid{columns:2;gap:.6rem;}.gl-nav-right .gl-filter-group{display:none;}}

--- a/backend/templates/frontend/homepage.html
+++ b/backend/templates/frontend/homepage.html
@@ -1209,14 +1209,13 @@ section { width:100%; border-bottom:0.5px solid var(--bdr); }
   letter-spacing:.06em; color:var(--dim); margin-top:.6rem; line-height:1.6;
 }
 
+/* 중복 900px 쿼리 통합 */
 @media(max-width:900px){
   #s-sub { padding:0; }
   .mem-hero { grid-template-columns:1fr; gap:2.5rem; padding:3rem 1.5rem; }
   .mem-stats { grid-template-columns:repeat(3,1fr); }
   .mem-plans { grid-template-columns:1fr; padding:0 1.5rem 3rem; }
   .mem-faq { grid-template-columns:1fr; gap:1.5rem; padding:2.5rem 1.5rem; }
-}
-@media(max-width:900px){
   .hero-inner{grid-template-columns:1fr;}
   .hero-right{display:none;}
   #s2,#s6{grid-template-columns:1fr;}
@@ -1232,6 +1231,20 @@ section { width:100%; border-bottom:0.5px solid var(--bdr); }
   .ft-div{display:none;}
   .ft-logo-area,.ft-nav-area,.ft-sns-area{border-bottom:0.5px solid var(--bdr);min-height:auto;padding:2.5rem;}
   .cf-row{grid-template-columns:1fr;}
+}
+
+/* CONTAINER QUERIES — 섹션 내부 컴포넌트용 */
+/* 갤러리 그리드 컨테이너 */
+#s3 { container-type: inline-size; container-name: s3; }
+@container s3 (max-width: 600px) {
+  .gal-grid { grid-template-columns: 1fr 1fr; grid-auto-rows: 150px; }
+  .gal-item { grid-column: span 1 !important; grid-row: span 1 !important; }
+}
+/* 채팅 쇼케이스 컨테이너 */
+#s6 { container-type: inline-size; container-name: s6; }
+@container s6 (max-width: 700px) {
+  .chat-showcase { grid-template-columns: 1fr; }
+  .chat-left { border-right: none; border-bottom: 0.5px solid var(--bdr); }
 }
 </style>
 </head>

--- a/backend/templates/frontend/membership.html
+++ b/backend/templates/frontend/membership.html
@@ -189,6 +189,16 @@
     }
     .back-btn:hover { background-color: #e2e2e2; }
 
+    /* CONTAINER QUERY — 플랜 카드 래퍼 기준 */
+    .plans-wrapper { container-type: inline-size; container-name: plans; }
+    @container plans (max-width: 700px) {
+      /* plans-wrapper 자체가 container라 내부 grid 재정의 불가 — 아래 미디어로 처리 */
+    }
+
+    @media (max-width: 1024px) {
+      .plans-wrapper { gap: 16px; }
+      .plan-card { padding: 24px 20px; }
+    }
     @media (max-width: 768px) {
       .plans-wrapper { grid-template-columns: 1fr; }
       .main-title { font-size: 26px; }
@@ -197,6 +207,11 @@
       .cta-inner { flex-direction: column; }
       .back-btn { order: 2; height: 50px; font-size: 16px; }
       .next-btn { order: 1; height: 60px; font-size: 20px; }
+    }
+    @media (max-width: 480px) {
+      .main-title { font-size: 22px; }
+      .plan-price { font-size: 28px; }
+      .plan-card { padding: 20px 16px; }
     }
   </style>
 </head>

--- a/backend/templates/frontend/profile.html
+++ b/backend/templates/frontend/profile.html
@@ -103,6 +103,22 @@ body{background:var(--bg);color:var(--ink);font-family:var(--f-thin);overflow-x:
 
 @keyframes fadeUp{from{opacity:0;transform:translateY(18px)}to{opacity:1;transform:translateY(0)}}
 
+/* CONTAINER QUERY — 우측 정보 패널 기준 */
+.pf-info-panel { container-type: inline-size; container-name: pf-info; }
+@container pf-info (max-width: 500px) {
+  .pf-stats { grid-template-columns: repeat(2,1fr); }
+  .pf-cta { flex-direction: column; }
+  .pf-gallery-grid { grid-template-columns: repeat(2,1fr); }
+}
+@container pf-info (max-width: 320px) {
+  .pf-name { font-size: 2.8rem; }
+  .pf-bio { font-size: 0.86rem; }
+}
+
+/* MEDIA QUERIES */
+@media(max-width:1024px){
+  .pf-main{grid-template-columns:360px 1fr;}
+}
 @media(max-width:900px){
   .pf-main{grid-template-columns:1fr;}
   .pf-img-panel{position:relative;height:60vw;top:0;}

--- a/backend/templates/frontend/video.html
+++ b/backend/templates/frontend/video.html
@@ -147,10 +147,20 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;over
 .vd-empty p{font-family:'DM Mono',monospace;font-size:.7rem;letter-spacing:.15em;text-transform:uppercase;margin-bottom:1rem;}
 .vd-empty a{font-family:'DM Mono',monospace;font-size:.6rem;letter-spacing:.14em;text-transform:uppercase;color:var(--acc);text-decoration:none;border-bottom:.5px solid var(--acc);}
 
+/* CONTAINER QUERY — 비디오 그리드 기준 */
+.vd-grid { container-type: inline-size; container-name: vd-grid; }
+@container vd-grid (max-width: 640px) {
+  .vd-grid-inner { justify-content: center; }
+  .yt-card { max-width: 280px; }
+}
+@container vd-grid (max-width: 400px) {
+  .yt-card { max-width: 100%; }
+  .yt-title { font-size: 0.92rem; }
+}
+
 @media(max-width:768px){
   .vd-grid-inner{justify-content:center;}
 }
-
 
 /* ── FOOTER ── */
 .vd-footer{


### PR DESCRIPTION
- 공통 브레이크포인트 정립: 1280/1024/768/480px
- chat.html: container-name=chat-main, 버블/입력창 컨테이너 쿼리 적용
- fanpage.html: container-name=fp-main, 카드 그리드 컨테이너 쿼리 적용
- homepage.html: 중복 900px 미디어 쿼리 통합, s3·s6 컨테이너 쿼리 추가
- membership.html: 1024/480px 브레이크포인트 추가
- profile.html: container-name=pf-info, stats·gallery 컨테이너 쿼리 적용
- video.html: container-name=vd-grid, 카드 크기 컨테이너 쿼리 적용
- gallery.html: container-name=gl-body, 컬럼 수 컨테이너 쿼리 적용