### PR TITLE
feat(ui): 상단 내비게이션(GNB) 메뉴 전면 재배치 및 히어로 스크롤 스타일 롤백

### DIFF
--- a/backend/templates/frontend/includes/homepage/_nav_auth.html
+++ b/backend/templates/frontend/includes/homepage/_nav_auth.html
@@ -8,6 +8,24 @@
   <div class="nav-center">
     <!-- 상단 GNB 메뉴: 메인 페이지 내 섹션 이동 (앵커) -->
     <div class="nav-desktop-menu" style="display:flex; align-items:center; gap:1.1rem; margin-right:auto; margin-left:2rem; font-family:var(--f-playful); font-size:0.85rem; letter-spacing:0.01em; text-transform:uppercase;">
+      <a href="/profile/" style="color:var(--ink); text-decoration:none; transition:opacity 0.2s;" onmouseover="this.style.opacity=0.6" onmouseout="this.style.opacity=1">Profile</a>
+      <a href="/gallery/" style="color:var(--ink); text-decoration:none; transition:opacity 0.2s;" onmouseover="this.style.opacity=0.6" onmouseout="this.style.opacity=1">Gallery</a>
+      <a href="/video/" style="color:var(--ink); text-decoration:none; transition:opacity 0.2s;" onmouseover="this.style.opacity=0.6" onmouseout="this.style.opacity=1">Video</a>
+      <a href="#s6" style="color:var(--ink); text-decoration:none; transition:opacity 0.2s;" onmouseover="this.style.opacity=0.6" onmouseout="this.style.opacity=1">Contact</a>
+
+      <!-- 로그인/유저 버튼 -->
+      {% if user.is_authenticated %}
+      <div class="auth-user-wrap" id="user-menu-wrap" style="margin-left:0.5rem; margin-right:0.5rem;">
+        <button id="auth-btn" class="logged-in" onclick="toggleUserMenu()">{{ user.username }} ▾</button>
+        <div class="user-dropdown" id="user-dropdown">
+          <a href="/mypage/">마이페이지</a>
+          <button class="logout-btn" onclick="doLogout()">로그아웃</button>
+        </div>
+      </div>
+      {% else %}
+      <button id="auth-btn" onclick="openAuth('login')" style="margin-left:0.5rem; margin-right:0.5rem;">로그인</button>
+      {% endif %}
+
       {% if user.is_authenticated %}
       <a href="/hari-chat/" style="color:var(--acc);text-decoration:none;font-weight:600;display:flex;align-items:center;gap:0.3rem;white-space:nowrap;">하리와 대화하기 <span style="font-size:1rem;">💬</span></a>
       {% else %}
@@ -15,25 +33,12 @@
       {% endif %}
       <!-- CTA 버튼 -->
       <a href="/mypage/" style="display:flex;align-items:center;gap:0.3rem;background:var(--acc);color:#fff;padding:0.4rem 0.7rem;text-decoration:none;font-family:var(--f-neo);font-size:0.75rem;letter-spacing:0;font-weight:500;margin-left:0.5rem;transition:background 0.2s;white-space:nowrap;" onmouseover="this.style.background='#ff4c6c'" onmouseout="this.style.background='var(--acc)'">마이페이지 ↗</a>
-      <a href="/membership/" style="display:flex;align-items:center;gap:0.3rem;background:var(--acc);color:#fff;padding:0.4rem 0.7rem;text-decoration:none;font-family:var(--f-neo);font-size:0.75rem;letter-spacing:0;font-weight:500;transition:background 0.2s;white-space:nowrap;" onmouseover="this.style.background='#ff4c6c'" onmouseout="this.style.background='var(--acc)'">멤버십 가입하기 ↗</a>
+      <a href="/membership/" style="display:flex;align-items:center;gap:0.3rem;background:var(--acc);color:#fff;padding:0.4rem 0.7rem;text-decoration:none;font-family:var(--f-neo);font-size:0.75rem;letter-spacing:0;font-weight:500;transition:background 0.2s;white-space:nowrap;" onmouseover="this.style.background='#ff4c6c'" onmouseout="this.style.background='var(--acc)'">멤버십 구독하기 ↗</a>
     </div>
 
     <!-- 로컬 전용 관리자 링크 -->
     {% if debug %}
     <a href="/admin-panel/" style="margin-left:1rem; font-family:'DM Mono',monospace; font-size:.6rem; letter-spacing:.12em; text-transform:uppercase; color:var(--acc2); border:0.5px solid var(--acc2); padding:5px 12px; text-decoration:none; transition:background .2s;" onmouseover="this.style.background='rgba(255,209,102,0.15)'" onmouseout="this.style.background='transparent'">Admin ⚙</a>
-    {% endif %}
-
-    <!-- 로그인/유저 버튼 -->
-    {% if user.is_authenticated %}
-    <div class="auth-user-wrap" id="user-menu-wrap">
-      <button id="auth-btn" class="logged-in" onclick="toggleUserMenu()">{{ user.username }} ▾</button>
-      <div class="user-dropdown" id="user-dropdown">
-        <a href="/mypage/">마이페이지</a>
-        <button class="logout-btn" onclick="doLogout()">로그아웃</button>
-      </div>
-    </div>
-    {% else %}
-    <button id="auth-btn" onclick="openAuth('login')">로그인</button>
     {% endif %}
 
     <!-- 햄버거 메뉴 -->

--- a/backend/templates/frontend/includes/homepage/_s1_hero.html
+++ b/backend/templates/frontend/includes/homepage/_s1_hero.html
@@ -2,13 +2,13 @@
 <section id="s1" style="position:relative;height:100vh;overflow:hidden;background-image:linear-gradient(rgba(0,0,0,0.1),rgba(0,0,0,0.3)),url({% static 'images/hari_image5.png' %});background-size:cover;background-position:center;background-repeat:no-repeat;">
 
   <!-- 로고 -->
-  <div style="position:absolute;top:100px;left:50px;z-index:10;pointer-events:none;">
+  <div style="position:absolute;top:60px;left:60px;z-index:10;pointer-events:none;">
     <img src="{% static 'images/hari_logo_none.png' %}?v=3" alt="HARI" style="height:140px;width:auto;filter:brightness(0);">
   </div>
 
   <!-- 하단 -->
   <div class="hero-bottom" style="font-family:var(--f-pixel);z-index:10;">
-    <div class="hero-bottom-text">WELCOME TO HARI S WORLD</div>
+    <div class="hero-bottom-text">WELCOME TO HARI'S WORLD</div>
     <div class="hero-scroll-hint">
       <div class="scroll-mouse"></div>
       <div class="scroll-line"></div>
@@ -18,3 +18,25 @@
   </div>
 
 </section>
+
+<style>
+/* 메인 히어로 하단 스크롤 영역 오버레이 디자인 수정 */
+#s1 .hero-bottom {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  border-top: none; /* 기존 border 제거 */
+  background: linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.3) 60%, transparent 100%);
+  padding: 5rem 4rem 2.5rem 4rem;
+}
+
+#s1 .hero-bottom-text {
+  letter-spacing: 0.3em;
+  font-size: 0.85rem;
+}
+
+#s1 .hero-scroll-hint {
+  letter-spacing: 0.25em;
+}
+</style>


### PR DESCRIPTION
- 글로벌 내비게이션 바 메뉴 가시성 및 접근성 개선 (`_nav_auth.html`)
  - 햄버거 메뉴에만 있던 주요 메뉴(Profile, Gallery, Video, Contact)를 메인 GNB로 노출
  - 메뉴 배치 순서를 사용자 플로우에 맞게 재정렬: [주요 탭 4종] -> [로그인/유저] -> [하리와 대화하기] -> [마이페이지] -> [멤버십 구독하기]
  - 멤버십 버튼 텍스트를 '가입하기'에서 '구독하기'로 변경
- 메인 히어로 하단 스크롤 인디케이터(`_s1_hero.html`) 컬러 스타일 롤백
  - 텍스트 및 마우스 아이콘 색상을 테마 오리지널 컬러(`var(--dim)`, `var(--acc)`)로 원복하여 기존 디자인 시스템 유지