### PR TITLE
feat(frontend): 프리미엄 비디오 UI 적용 및 세로 잘림 최적화 (video.html 동기화)

### DIFF
--- a/backend/templates/frontend/includes/homepage/_s2_profile.html
+++ b/backend/templates/frontend/includes/homepage/_s2_profile.html
@@ -1,8 +1,7 @@
 {% load static %}
 <section id="s2">
-  <div class="profile-top-row" style="display:none;">
-    <h2 class="profile-vh-title">Artist Profile</h2>
-    <a class="profile-all-btn" href="#">View All</a>
+  <div style="margin-bottom: 3rem;">
+    <h2 class="sec-title">PROFILE</h2>
   </div>
 
   <div class="profile-main-container">

--- a/backend/templates/frontend/includes/homepage/_s4_video.html
+++ b/backend/templates/frontend/includes/homepage/_s4_video.html
@@ -9,14 +9,13 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-end;
-    padding: 2.5rem 2.5rem 1.5rem;
+    padding: 2rem 2.5rem 0.5rem;
     border-bottom: 0.5px solid var(--bdr);
   }
 
   .s4-title {
     font-family: 'Bebas Neue', sans-serif;
-    font-size: clamp(2.5rem, 5vw, 5rem);
-    font-weight: 400;
+    font-size: clamp(2.2rem, 4vw, 3.5rem);
     color: var(--ink);
     line-height: 1;
     margin: 0;
@@ -36,109 +35,109 @@
   }
   .s4-more:hover { color: var(--ink); }
 
-  /* Swiper 재구성 및 Custom CSS */
-  .swiper-video { /* container if we decide to re-init swiper */
-    overflow: hidden;
-  }
-  /* 만약 Swiper JS가 없더라도 두 개 띄우기용 (왼쪽 정렬 적용) */
-  .swiper-wrapper.static-view {
-    display: flex !important;
-    justify-content: flex-start; /* 화면 왼쪽부터 나란히 배치 */
-    gap: 24px; /* 영상 간격 */
-    transform: none !important;
+  /* Premium Grid Layout */
+  .premium-video-grid {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 2rem;
+    padding: 2rem 2.5rem 3rem;
+    flex-wrap: wrap;
   }
 
-  .yt-card {
+  .premium-vid-card {
     display: flex;
     flex-direction: column;
-    align-items: flex-start; /* 텍스트도 왼쪽 언저리로 자연스럽게 */
-    max-width: 340px; /* Shorts가 예쁘게 보이는 크기 */
     width: 100%;
-    margin: 0; /* 중앙 강제 정렬 해제 */
+    max-width: 220px; /* 창 100%일 때 세로 잘림 막기 위해 확 줄임 */
+    transition: transform 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  .premium-vid-card:hover {
+    transform: translateY(-10px);
   }
 
-  /* 9:16 Shorts 비율 썸네일(iframe) 래퍼 */
-  .yt-thumb-wrap {
+  /* 9:16 Shorts Wrapper */
+  .premium-vid-thumb {
     position: relative;
     width: 100%;
-    padding-bottom: 177.78%; /* 16:9 역방향 9:16 */
-    background: #000;
-    border-radius: 4px;
+    padding-bottom: 177.78%; 
+    background: #111;
+    border-radius: 18px; /* 둥근 모서리로 더 부드럽고 세련되게 */
     overflow: hidden;
-    box-shadow: 0 10px 20px rgba(0,0,0,0.1);
+    box-shadow: 0 16px 36px rgba(0,0,0,0.14); /* 고급스러운 그림자 */
+    margin-bottom: 1.4rem;
   }
 
-  /* 꽉 차게 유튜브 iframe 임베드 */
-  .yt-thumb-wrap iframe {
+  .premium-vid-thumb iframe {
     position: absolute;
     top: 0; left: 0; width: 100%; height: 100%;
     border: none;
   }
 
-  /* Shorts Badge - 우측 하단 */
-  .yt-shorts-badge {
+  /* Shorts Badge Overlap */
+  .premium-shorts-badge {
     position: absolute; 
-    bottom: 10px; 
-    right: 10px;
-    background: #ff0000; 
+    bottom: 16px; 
+    right: 16px;
+    background: rgba(255, 0, 0, 0.9); 
     color: #fff; 
-    font-size: 0.7rem; 
+    font-size: 0.75rem; 
     font-weight: 700;
-    padding: 2px 6px; 
-    border-radius: 4px; 
+    padding: 5px 12px; 
+    border-radius: 20px; 
     display: flex; 
     align-items: center; 
-    font-family: sans-serif;
-    pointer-events: none; /* iframe 클릭 방해 방지 */
+    gap: 4px;
+    font-family: 'Apple SD Gothic Neo', sans-serif;
+    pointer-events: none;
+    box-shadow: 0 4px 10px rgba(255,0,0,0.3);
   }
 
-  .yt-info { 
-    text-align: left; /* 중앙 정렬에서 왼쪽 정렬로 변경 (요청사항 매칭) */
-    margin-top: 1rem; 
+  .premium-vid-info {
+    text-align: left; 
     width: 100%;
-    padding: 0 4px;
+    padding: 0 0.5rem;
   }
   
-  .yt-title { 
-    font-family: var(--f-neo);
+  .premium-vid-title { 
+    font-family: 'Pretendard', 'Apple SD Gothic Neo', sans-serif;
     font-size: 1.05rem; 
-    font-weight: 500; 
-    color: #222; 
+    font-weight: 700; 
+    color: var(--ink); 
     line-height: 1.3;
     margin-bottom: 0.4rem;
+    letter-spacing: -0.01em;
+    word-break: keep-all;
   }
   
-  .yt-meta span {
-    font-family: var(--f-pixel);
-    font-size: 0.75rem; 
-    color: var(--dim);
-    display: inline-block;
-    margin-bottom: 0.8rem;
+  .premium-vid-meta {
+    font-family: 'DM Mono', monospace;
+    font-size: 0.7rem; 
+    color: #888;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.7rem;
+    text-transform: uppercase;
   }
 
-  .yt-link {
+  .premium-vid-link {
     display: inline-flex;
     align-items: center;
-    justify-content: flex-start;
     gap: 6px;
-    font-size: 0.8rem;
+    font-family: 'Pretendard', 'Apple SD Gothic Neo', sans-serif;
+    font-size: 0.9rem;
     color: #555;
     text-decoration: none;
-    font-weight: 500;
+    font-weight: 600;
     transition: color 0.2s;
   }
-  .yt-link:hover {
-    color: #ff7b8a;
-  }
-  .yt-link svg {
-    margin-top: -1px;
+  .premium-vid-link:hover {
+    color: var(--acc);
   }
 
-  @media (max-width: 768px) {
-    .s4-title { font-size: 4rem; }
-    .swiper-wrapper.static-view { 
-      grid-template-columns: 1fr; 
-      gap: 3rem; 
+  @media (max-width: 900px) {
+    .premium-video-grid {
+      gap: 2rem;
+      padding: 2rem 1.5rem 4rem;
     }
   }
 </style>
@@ -146,47 +145,64 @@
 <section id="s4">
   <div class="s4-header">
     <h2 class="s4-title">VIDEOS</h2>
-    <a class="s4-more" href="/video/">모두 보기 ↗</a>
+    <a class="s4-more" href="/video/">VIEW ALL ↗</a>
   </div>
 
-  <!-- 전달해주신 코드 원형 적용 -->
-  <div class="swiper-video">
-    <div class="swiper-wrapper static-view" id="swiper-wrapper-46a1b4e65be38254" aria-live="polite" style="transform: translate3d(0px, 0px, 0px);">
+  <div class="premium-video-grid">
 
-      <!-- 영상 1 -->
-      <div class="swiper-slide yt-card swiper-slide-active" role="group" aria-label="1 / 2" style="margin-right: 16px;">
-        <div class="yt-thumb-wrap">
-          <iframe src="https://www.youtube.com/embed/7Ytd-ZDlO0c?mute=1&amp;loop=1&amp;playlist=7Ytd-ZDlO0c" title="YouTube Shorts" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="">
-          </iframe>
-          <span class="yt-shorts-badge">▶ Shorts</span>
-        </div>
-        <div class="yt-info">
-          <div class="yt-title">&lt;테크뉴스&gt; 초파리 뇌의 비밀</div>
-          <div class="yt-meta"><span>최근 소식</span></div>
-          <a class="yt-link" href="https://www.youtube.com/shorts/7Ytd-ZDlO0c" target="_blank" rel="noopener">
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg>
-            YouTube 앱에서 보기 ↗
-          </a>
-        </div>
+    <!-- Video 1 -->
+    <article class="premium-vid-card">
+      <div class="premium-vid-thumb">
+        <iframe src="https://www.youtube.com/embed/TdvvozjmKJQ?mute=1&amp;loop=1&amp;playlist=TdvvozjmKJQ" title="YouTube Shorts" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe>
+        <span class="premium-shorts-badge">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg>
+          Shorts
+        </span>
       </div>
-
-      <!-- 영상 2 -->
-      <div class="swiper-slide yt-card swiper-slide-next" role="group" aria-label="2 / 2" style="margin-right: 16px;">
-        <div class="yt-thumb-wrap">
-          <iframe src="https://www.youtube.com/embed/LFBHDLvL2Yw?mute=1&amp;loop=1&amp;playlist=LFBHDLvL2Yw" title="YouTube Shorts" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="">
-          </iframe>
-          <span class="yt-shorts-badge">▶ Shorts</span>
-        </div>
-        <div class="yt-info">
-          <div class="yt-title">&lt;테크뉴스&gt; 구글 Stitch</div>
-          <div class="yt-meta"><span>최근 소식</span></div>
-          <a class="yt-link" href="https://www.youtube.com/shorts/LFBHDLvL2Yw" target="_blank" rel="noopener">
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg>
-            YouTube 앱에서 보기 ↗
-          </a>
-        </div>
+      <div class="premium-vid-info">
+        <div class="premium-vid-title">&lt;테크뉴스&gt; 구글 딥마인드의 비장의 무기</div>
+        <div class="premium-vid-meta">Tech Issue</div>
+        <a class="premium-vid-link" href="https://www.youtube.com/shorts/TdvvozjmKJQ" target="_blank" rel="noopener">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg> YouTube 앱에서 보기 ↗
+        </a>
       </div>
+    </article>
 
-    </div>
+    <!-- Video 2 -->
+    <article class="premium-vid-card">
+      <div class="premium-vid-thumb">
+        <iframe src="https://www.youtube.com/embed/LFBHDLvL2Yw?mute=1&amp;loop=1&amp;playlist=LFBHDLvL2Yw" title="YouTube Shorts" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe>
+        <span class="premium-shorts-badge">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg>
+          Shorts
+        </span>
+      </div>
+      <div class="premium-vid-info">
+        <div class="premium-vid-title">&lt;테크뉴스&gt; 구글 stitch의 변신</div>
+        <div class="premium-vid-meta">Review &amp; Update</div>
+        <a class="premium-vid-link" href="https://www.youtube.com/shorts/LFBHDLvL2Yw" target="_blank" rel="noopener">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg> YouTube 앱에서 보기 ↗
+        </a>
+      </div>
+    </article>
+
+    <!-- Video 3 -->
+    <article class="premium-vid-card">
+      <div class="premium-vid-thumb">
+        <iframe src="https://www.youtube.com/embed/7Ytd-ZDlO0c?mute=1&amp;loop=1&amp;playlist=7Ytd-ZDlO0c" title="YouTube Shorts" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe>
+        <span class="premium-shorts-badge">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg>
+          Shorts
+        </span>
+      </div>
+      <div class="premium-vid-info">
+        <div class="premium-vid-title">&lt;테크뉴스&gt; 아무도 몰랐던 초파리 뇌의 비밀</div>
+        <div class="premium-vid-meta">Science Note</div>
+        <a class="premium-vid-link" href="https://www.youtube.com/shorts/7Ytd-ZDlO0c" target="_blank" rel="noopener">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg> YouTube 앱에서 보기 ↗
+        </a>
+      </div>
+    </article>
+
   </div>
 </section>

--- a/backend/templates/frontend/video.html
+++ b/backend/templates/frontend/video.html
@@ -111,34 +111,93 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;over
   gap:24px;
 }
 
-/* ── YT CARD (메인과 동일) ── */
-.yt-card{
-  display:flex;flex-direction:column;align-items:flex-start;
-  max-width:340px;width:100%;margin:0;
+/* ── PREMIUM VIDEO CARD (메인 페이지 동기화) ── */
+.premium-vid-card {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 260px; /* 전체 페이지이므로 메인보다 살짝 크게 여유있게 배치 */
+  transition: transform 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
-.yt-thumb-wrap{
-  position:relative;width:100%;padding-bottom:177.78%;
-  background:#000;border-radius:4px;overflow:hidden;
-  box-shadow:0 10px 20px rgba(0,0,0,0.1);
+.premium-vid-card:hover {
+  transform: translateY(-8px);
 }
-.yt-thumb-wrap iframe{
-  position:absolute;top:0;left:0;width:100%;height:100%;border:none;
+
+.premium-vid-thumb {
+  position: relative;
+  width: 100%;
+  padding-bottom: 177.78%; 
+  background: #111;
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: 0 16px 36px rgba(0,0,0,0.14);
+  margin-bottom: 1.4rem;
 }
-.yt-shorts-badge{
-  position:absolute;bottom:10px;right:10px;
-  background:#ff0000;color:#fff;font-size:.7rem;font-weight:700;
-  padding:2px 6px;border-radius:4px;
-  display:flex;align-items:center;font-family:sans-serif;
-  pointer-events:none;
+
+.premium-vid-thumb iframe {
+  position: absolute;
+  top: 0; left: 0; width: 100%; height: 100%;
+  border: none;
 }
-.yt-info{text-align:left;margin-top:1rem;width:100%;padding:0 4px;}
-.yt-title{font-family:var(--f-neo);font-size:1.05rem;font-weight:500;color:#222;line-height:1.3;margin-bottom:.4rem;}
-.yt-meta span{font-family:var(--f-pixel);font-size:.75rem;color:var(--dim);display:inline-block;margin-bottom:.8rem;}
-.yt-link{
-  display:inline-flex;align-items:center;gap:6px;
-  font-size:.8rem;color:#555;text-decoration:none;font-weight:500;transition:color .2s;
+
+.premium-shorts-badge {
+  position: absolute; 
+  bottom: 16px; 
+  right: 16px;
+  background: rgba(255, 0, 0, 0.9); 
+  color: #fff; 
+  font-size: 0.75rem; 
+  font-weight: 700;
+  padding: 5px 12px; 
+  border-radius: 20px; 
+  display: flex; 
+  align-items: center; 
+  gap: 4px;
+  font-family: 'Apple SD Gothic Neo', sans-serif;
+  pointer-events: none;
+  box-shadow: 0 4px 10px rgba(255,0,0,0.3);
 }
-.yt-link:hover{color:#ff7b8a;}
+
+.premium-vid-info {
+  text-align: left; 
+  width: 100%;
+  padding: 0 0.5rem;
+}
+
+.premium-vid-title { 
+  font-family: 'Pretendard', 'Apple SD Gothic Neo', sans-serif;
+  font-size: 1.05rem; 
+  font-weight: 700; 
+  color: var(--ink); 
+  line-height: 1.3;
+  margin-bottom: 0.4rem;
+  letter-spacing: -0.01em;
+  word-break: keep-all;
+}
+
+.premium-vid-meta {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.7rem; 
+  color: #888;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.8rem;
+  text-transform: uppercase;
+}
+
+.premium-vid-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: 'Pretendard', 'Apple SD Gothic Neo', sans-serif;
+  font-size: 0.85rem;
+  color: #555;
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.2s;
+}
+.premium-vid-link:hover {
+  color: var(--acc);
+}
 
 /* ── EMPTY STATE ── */
 .vd-empty{
@@ -151,11 +210,11 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;over
 .vd-grid { container-type: inline-size; container-name: vd-grid; }
 @container vd-grid (max-width: 640px) {
   .vd-grid-inner { justify-content: center; }
-  .yt-card { max-width: 280px; }
+  .premium-vid-card { max-width: 280px; }
 }
 @container vd-grid (max-width: 400px) {
-  .yt-card { max-width: 100%; }
-  .yt-title { font-size: 0.92rem; }
+  .premium-vid-card { max-width: 100%; }
+  .premium-vid-title { font-size: 0.95rem; }
 }
 
 @media(max-width:768px){
@@ -238,47 +297,59 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;over
 <div class="vd-grid" id="vd-grid">
   <div class="vd-grid-inner">
 
-    <!-- 영상 1 -->
-    <div class="yt-card">
-      <div class="yt-thumb-wrap">
-        <iframe src="https://www.youtube.com/embed/7Ytd-ZDlO0c?mute=1&loop=1&playlist=7Ytd-ZDlO0c"
-          title="YouTube Shorts" frameborder="0"
-          referrerpolicy="strict-origin-when-cross-origin"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-          allowfullscreen>
-        </iframe>
-        <span class="yt-shorts-badge">▶ Shorts</span>
+    <!-- Video 1 -->
+    <article class="premium-vid-card">
+      <div class="premium-vid-thumb">
+        <iframe src="https://www.youtube.com/embed/TdvvozjmKJQ?mute=1&amp;loop=1&amp;playlist=TdvvozjmKJQ" title="YouTube Shorts" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe>
+        <span class="premium-shorts-badge">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg>
+          Shorts
+        </span>
       </div>
-      <div class="yt-info">
-        <div class="yt-title">&lt;테크뉴스&gt; 초파리 뇌의 비밀</div>
-        <div class="yt-meta"><span>최근 소식</span></div>
-        <a class="yt-link" href="https://www.youtube.com/shorts/7Ytd-ZDlO0c" target="_blank" rel="noopener">
-          <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg>
-          YouTube 앱에서 보기 ↗
+      <div class="premium-vid-info">
+        <div class="premium-vid-title">&lt;테크뉴스&gt; 구글 딥마인드의 비장의 무기</div>
+        <div class="premium-vid-meta">Tech Issue</div>
+        <a class="premium-vid-link" href="https://www.youtube.com/shorts/TdvvozjmKJQ" target="_blank" rel="noopener">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg> YouTube 앱에서 보기 ↗
         </a>
       </div>
-    </div>
+    </article>
 
-    <!-- 영상 2 -->
-    <div class="yt-card">
-      <div class="yt-thumb-wrap">
-        <iframe src="https://www.youtube.com/embed/LFBHDLvL2Yw?mute=1&loop=1&playlist=LFBHDLvL2Yw"
-          title="YouTube Shorts" frameborder="0"
-          referrerpolicy="strict-origin-when-cross-origin"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-          allowfullscreen>
-        </iframe>
-        <span class="yt-shorts-badge">▶ Shorts</span>
+    <!-- Video 2 -->
+    <article class="premium-vid-card">
+      <div class="premium-vid-thumb">
+        <iframe src="https://www.youtube.com/embed/LFBHDLvL2Yw?mute=1&amp;loop=1&amp;playlist=LFBHDLvL2Yw" title="YouTube Shorts" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe>
+        <span class="premium-shorts-badge">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg>
+          Shorts
+        </span>
       </div>
-      <div class="yt-info">
-        <div class="yt-title">&lt;테크뉴스&gt; 구글 Stitch</div>
-        <div class="yt-meta"><span>최근 소식</span></div>
-        <a class="yt-link" href="https://www.youtube.com/shorts/LFBHDLvL2Yw" target="_blank" rel="noopener">
-          <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg>
-          YouTube 앱에서 보기 ↗
+      <div class="premium-vid-info">
+        <div class="premium-vid-title">&lt;테크뉴스&gt; 구글 stitch의 변신</div>
+        <div class="premium-vid-meta">Review &amp; Update</div>
+        <a class="premium-vid-link" href="https://www.youtube.com/shorts/LFBHDLvL2Yw" target="_blank" rel="noopener">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg> YouTube 앱에서 보기 ↗
         </a>
       </div>
-    </div>
+    </article>
+
+    <!-- Video 3 -->
+    <article class="premium-vid-card">
+      <div class="premium-vid-thumb">
+        <iframe src="https://www.youtube.com/embed/7Ytd-ZDlO0c?mute=1&amp;loop=1&amp;playlist=7Ytd-ZDlO0c" title="YouTube Shorts" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe>
+        <span class="premium-shorts-badge">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg>
+          Shorts
+        </span>
+      </div>
+      <div class="premium-vid-info">
+        <div class="premium-vid-title">&lt;테크뉴스&gt; 아무도 몰랐던 초파리 뇌의 비밀</div>
+        <div class="premium-vid-meta">Science Note</div>
+        <a class="premium-vid-link" href="https://www.youtube.com/shorts/7Ytd-ZDlO0c" target="_blank" rel="noopener">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg> YouTube 앱에서 보기 ↗
+        </a>
+      </div>
+    </article>
 
     <div class="vd-empty" id="vd-empty">
       <p>해당 카테고리에 영상이 없어요</p>
@@ -300,7 +371,7 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;over
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-  const total = document.querySelectorAll('.yt-card').length;
+  const total = document.querySelectorAll('.premium-vid-card').length;
   const el = document.getElementById('video-total-count');
   if (el) el.textContent = total;
 });


### PR DESCRIPTION
- 홈페이지 비디오 섹션(`_s4_video.html`):
  - 기존의 스와이퍼 구조를 걷어내고, 데스크톱 한 화면에 스크롤 없이 가득 차도록 3단 그리드 레이아웃 적용
  - 노트북 환경의 100% 비율에서도 세로 잘림이 발생하지 않도록 비디오 타일 폭(`max-width: 220px`) 및 내부 상하 여백 최적화
  - 모서리 라운딩(18px), 마우스 호버 애니메이션, Shorts 뱃지, 뉴스/매거진 스타일 형태의 깔끔한 타이포그래피 등 프리미엄 디자인 도입
  - 사용자 피드백을 반영해 유튜브 `iframe`의 `referrerpolicy` 속성을 원복하여 재생 제한 문제 해결

- 비디오 페이지(`video.html`):
  - 홈페이지 프론트 개편안과 동일한 '프리미엄 비디오 카드' UI 구조 및 스타일시트(CSS) 이식
  - 랜딩 페이지와 동일하게 3개의 영상(알레테리아, 스티치, 초파리) 콘텐츠 반영 및 순서 동기화