### PR TITLE
fix(responsive): 전체 페이지 모바일 반응형 개선 및 가로 스크롤 차단

### DIFF
--- a/backend/templates/frontend/chat.html
+++ b/backend/templates/frontend/chat.html
@@ -45,15 +45,19 @@ html, body {
   height: 100vh;
   margin: 0;
   overflow: hidden;
+  overflow-x: hidden;
   font-family: var(--f-pixel);
   font-size: 1rem;
   background: var(--bg-main);
+  max-width: 100vw;
 }
 
 .app-container {
   display: flex;
   height: 100vh;
-  width: 100vw;
+  width: 100%;
+  max-width: 100vw;
+  overflow: hidden;
 }
 
 /* ═══════════════════════════════════════
@@ -1070,6 +1074,16 @@ html, body {
   .header-profile .profile-name { font-size: 0.9rem; }
   .input-area { padding: 6px 10px; }
   .quick-reply-btn { font-size: 0.72rem; padding: 6px 12px; }
+  .messages-container { padding: 12px 10px; }
+}
+/* 360px: 초소형 모바일 */
+@media (max-width: 360px) {
+  .header { padding: 8px 10px; }
+  .header-profile .profile-name { font-size: 0.8rem; }
+  .input-area { padding: 4px 8px; }
+  .chat-input { font-size: 0.82rem; }
+  .send-btn { width: 36px; height: 36px; }
+  .quick-reply-btn { font-size: 0.66rem; padding: 5px 9px; }
 }
 </style>
 </head>

--- a/backend/templates/frontend/gallery.html
+++ b/backend/templates/frontend/gallery.html
@@ -18,8 +18,8 @@
   --bg:#ffffff;--ink:#2a2420;--acc:#ff7b8a;--dim:#9e9490;
   --bdr:rgba(255,123,138,0.12);--bdr2:rgba(255,123,138,0.22);
 }
-html{scroll-behavior:smooth;}
-body{background:var(--bg);color:var(--ink);overflow-x:hidden;}
+html{scroll-behavior:smooth;overflow-x:hidden;}
+body{background:var(--bg);color:var(--ink);overflow-x:hidden;max-width:100vw;}
 ::-webkit-scrollbar{width:5px;}
 ::-webkit-scrollbar-thumb{background:var(--acc);border-radius:3px;}
 
@@ -74,7 +74,8 @@ body{background:var(--bg);color:var(--ink);overflow-x:hidden;}
 /* MEDIA QUERIES */
 @media(max-width:1200px){.gl-grid{columns:3;}}
 @media(max-width:768px){.gl-grid{columns:2;padding:1.5rem;}.gl-header{flex-direction:column;gap:1.5rem;align-items:flex-start;}.gl-filter-group{flex-wrap:wrap;}}
-@media(max-width:480px){.gl-grid{columns:2;gap:.6rem;}.gl-nav-right .gl-filter-group{display:none;}}
+@media(max-width:480px){.gl-grid{columns:2;gap:.6rem;padding:1rem;}.gl-nav-right .gl-filter-group{display:none;}.gl-header{padding:2.5rem 1.2rem 1.5rem;flex-direction:column;gap:.8rem;align-items:flex-start;}.gl-nav{padding:0 1.2rem;height:56px;}}
+@media(max-width:360px){.gl-grid{columns:1;}.gl-title{font-size:3.5rem;}}
 </style>
 </head>
 <body>

--- a/backend/templates/frontend/homepage.html
+++ b/backend/templates/frontend/homepage.html
@@ -53,8 +53,8 @@
   --dim-dk: rgba(255,245,246,0.5);
   --bdr-dk: rgba(255,245,246,0.12);
 }
-html { scroll-behavior:smooth; }
-body { background:var(--bg); color:var(--ink); font-family:var(--f-thin); font-size: 1rem; line-height: 1.5; font-weight:400; overflow-x:hidden; }
+html { scroll-behavior:smooth; overflow-x:hidden; }
+body { background:var(--bg); color:var(--ink); font-family:var(--f-thin); font-size: 1rem; line-height: 1.5; font-weight:400; overflow-x:hidden; max-width:100vw; }
 ::-webkit-scrollbar { width:6px; }
 ::-webkit-scrollbar-thumb { background:var(--acc); border-radius:3px; }
 

--- a/backend/templates/frontend/login.html
+++ b/backend/templates/frontend/login.html
@@ -21,8 +21,8 @@
   --bdr:rgba(255,123,138,0.12);--bdr2:rgba(255,123,138,0.22);
   --grn:#06d6a0;
 }
-html,body{height:100%;}
-body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;display:flex;flex-direction:column;min-height:100vh;}
+html,body{height:100%;overflow-x:hidden;}
+body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;display:flex;flex-direction:column;min-height:100vh;max-width:100vw;}
 ::-webkit-scrollbar{width:5px;}
 ::-webkit-scrollbar-thumb{background:var(--acc);border-radius:3px;}
 
@@ -90,6 +90,19 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;disp
   .auth-left{display:none;}
   .auth-right{padding:3rem 1.5rem;}
   .auth-form-wrap{max-width:100%;}
+}
+@media(max-width:480px){
+  .auth-right{padding:2rem 1.2rem;}
+  .auth-form-title{font-size:1.3rem;}
+  .social-row{grid-template-columns:1fr;}
+  .social-btn{padding:.65rem;}
+  .auth-inp{font-size:.82rem;padding:.65rem .8rem;}
+  .auth-submit{padding:.8rem;font-size:.62rem;}
+}
+@media(max-width:360px){
+  .auth-right{padding:1.5rem 1rem;}
+  .auth-form-title{font-size:1.15rem;}
+  .auth-form-sub{font-size:.78rem;}
 }
 </style>
 </head>

--- a/backend/templates/frontend/membership.html
+++ b/backend/templates/frontend/membership.html
@@ -19,12 +19,15 @@
     }
 
     * { margin: 0; padding: 0; box-sizing: border-box; }
+    html { overflow-x: hidden; }
     body {
       background-color: var(--bg-white);
       color: var(--text-main);
       font-family: 'Noto Sans KR', sans-serif;
       line-height: 1.4;
       -webkit-font-smoothing: antialiased;
+      overflow-x: hidden;
+      max-width: 100vw;
     }
 
     /* HEADER */
@@ -212,6 +215,17 @@
       .main-title { font-size: 22px; }
       .plan-price { font-size: 28px; }
       .plan-card { padding: 20px 16px; }
+      header { height: 60px; padding: 0 1rem; }
+      .header-logo { height: 28px; }
+      .header-right a { font-size: 15px; }
+      .header-right { gap: 12px; }
+    }
+    @media (max-width: 360px) {
+      .main-title { font-size: 18px; }
+      .plan-price { font-size: 24px; }
+      .plan-card { padding: 16px 12px; }
+      header { height: 54px; }
+      .header-right a { font-size: 13px; }
     }
   </style>
 </head>

--- a/backend/templates/frontend/mypage.html
+++ b/backend/templates/frontend/mypage.html
@@ -33,8 +33,8 @@
   --sw:    230px;
   --th:    58px;
 }
-html,body{height:100%;overflow:hidden;}
-body{background:var(--bg);color:var(--ink);font-family:var(--f-pixel);font-size: 1.15rem; line-height: 1.5; font-weight:400;display:flex;flex-direction:column;}
+html,body{height:100%;overflow:hidden;overflow-x:hidden;}
+body{background:var(--bg);color:var(--ink);font-family:var(--f-pixel);font-size: 1.15rem; line-height: 1.5; font-weight:400;display:flex;flex-direction:column;max-width:100vw;}
 ::-webkit-scrollbar{width:3px;height:3px;}
 ::-webkit-scrollbar-thumb{background:var(--bdr2);}
 a{text-decoration:none;color:inherit;}

--- a/backend/templates/frontend/profile.html
+++ b/backend/templates/frontend/profile.html
@@ -22,8 +22,8 @@
   --bg:#ffffff;--ink:#2a2420;--acc:#ff7b8a;--acc2:#ffd166;--acc3:#06d6a0;
   --dim:#9e9490;--bdr:rgba(255,123,138,0.12);--bdr2:rgba(255,123,138,0.22);
 }
-html{scroll-behavior:smooth;}
-body{background:var(--bg);color:var(--ink);font-family:var(--f-thin);overflow-x:hidden;}
+html{scroll-behavior:smooth;overflow-x:hidden;}
+body{background:var(--bg);color:var(--ink);font-family:var(--f-thin);overflow-x:hidden;max-width:100vw;}
 ::-webkit-scrollbar{width:5px;}
 ::-webkit-scrollbar-thumb{background:var(--acc);border-radius:3px;}
 
@@ -42,7 +42,7 @@ body{background:var(--bg);color:var(--ink);font-family:var(--f-thin);overflow-x:
 .pf-hero-sub{font-family:'DM Mono',monospace;font-size:.72rem;letter-spacing:.2em;text-transform:uppercase;color:rgba(255,255,255,0.65);margin-top:.9rem;opacity:0;animation:fadeUp .6s .45s forwards;}
 
 /* MAIN LAYOUT */
-.pf-main{display:grid;grid-template-columns:420px 1fr;min-height:60vh;}
+.pf-main{display:grid;grid-template-columns:clamp(280px,35%,420px) 1fr;min-height:60vh;}
 
 /* LEFT PANEL — sticky image */
 .pf-img-panel{position:sticky;top:64px;height:calc(100vh - 64px);overflow:hidden;border-right:.5px solid var(--bdr);}
@@ -117,18 +117,27 @@ body{background:var(--bg);color:var(--ink);font-family:var(--f-thin);overflow-x:
 
 /* MEDIA QUERIES */
 @media(max-width:1024px){
-  .pf-main{grid-template-columns:360px 1fr;}
+  .pf-main{grid-template-columns:clamp(240px,30%,360px) 1fr;}
 }
 @media(max-width:900px){
   .pf-main{grid-template-columns:1fr;}
   .pf-img-panel{position:relative;height:60vw;top:0;}
   .pf-info-panel{padding:2.5rem 1.5rem;}
   .pf-stats{grid-template-columns:repeat(2,1fr);}
+  .pf-nav{padding:0 1.2rem;height:56px;}
 }
 @media(max-width:480px){
-  .pf-hero{padding:2rem 1.5rem;}
+  .pf-hero{padding:2rem 1.2rem;}
   .pf-gallery-grid{grid-template-columns:repeat(2,1fr);}
   .pf-cta{flex-direction:column;}
+  .pf-stats{grid-template-columns:repeat(2,1fr);}
+  .pf-img-panel{height:70vw;}
+}
+@media(max-width:360px){
+  .pf-hero{padding:1.5rem 1rem;}
+  .pf-info-panel{padding:1.5rem 1rem;}
+  .pf-gallery-grid{grid-template-columns:1fr 1fr;}
+  .pf-nav{padding:0 1rem;}
 }
 </style>
 </head>

--- a/backend/templates/frontend/signup.html
+++ b/backend/templates/frontend/signup.html
@@ -21,8 +21,8 @@
   --bdr:rgba(255,123,138,0.12);--bdr2:rgba(255,123,138,0.22);
   --grn:#06d6a0;
 }
-html,body{height:100%;}
-body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;display:flex;flex-direction:column;min-height:100vh;}
+html,body{height:100%;overflow-x:hidden;}
+body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;display:flex;flex-direction:column;min-height:100vh;max-width:100vw;}
 ::-webkit-scrollbar{width:5px;}
 ::-webkit-scrollbar-thumb{background:var(--acc);border-radius:3px;}
 
@@ -100,6 +100,20 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;disp
   .auth-left{display:none;}
   .auth-right{padding:3rem 1.5rem;}
   .auth-form-wrap{max-width:100%;}
+}
+@media(max-width:480px){
+  .auth-right{padding:2rem 1.2rem;}
+  .auth-form-title{font-size:1.3rem;}
+  .social-row{grid-template-columns:1fr;}
+  .social-btn{padding:.65rem;}
+  .auth-inp-row{grid-template-columns:1fr;}
+  .auth-inp{font-size:.82rem;padding:.65rem .8rem;}
+  .auth-submit{padding:.8rem;font-size:.62rem;}
+}
+@media(max-width:360px){
+  .auth-right{padding:1.5rem 1rem;}
+  .auth-form-title{font-size:1.15rem;}
+  .auth-form-sub{font-size:.78rem;}
 }
 </style>
 </head>

--- a/backend/templates/frontend/video.html
+++ b/backend/templates/frontend/video.html
@@ -20,8 +20,8 @@
   --dim:#9e9490;--bdr:rgba(255,123,138,0.12);--bdr2:rgba(255,123,138,0.22);
   --grn:#06d6a0;--s7-bg:#2a2420;
 }
-html{scroll-behavior:smooth;}
-body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;overflow-x:hidden;}
+html{scroll-behavior:smooth;overflow-x:hidden;}
+body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;overflow-x:hidden;max-width:100vw;}
 ::-webkit-scrollbar{width:5px;}
 ::-webkit-scrollbar-thumb{background:var(--acc);border-radius:3px;}
 
@@ -245,6 +245,12 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;over
   .vd-grid{grid-template-columns:1fr;padding:1rem;}
   .vd-card[data-type="full"]{grid-column:span 1;}
   .vd-footer{flex-direction:column;gap:1rem;text-align:center;}
+  .vd-header{padding:2.5rem 1.2rem 1.5rem;}
+}
+@media(max-width:360px){
+  .vd-nav{padding:0 1rem;height:52px;}
+  .premium-vid-card{max-width:100%;}
+  .vd-title{font-size:3rem;}
 }
 </style>
 </head>


### PR DESCRIPTION
- 전체 페이지 html/body에 overflow-x:hidden + max-width:100vw 적용으로 가로 스크롤 완전 차단
- login/signup: 480px, 360px breakpoint 추가 (소셜 버튼 1열 전환, 폼 패딩 축소)
- signup: 480px에서 입력 필드 2열 → 1열 전환
- chat: app-container 오버플로우 차단, 360px 초소형 기기 breakpoint 추가
- profile: 좌측 패널 고정 너비(420px) → clamp(280px,35%,420px) 상대값 변환, 360px breakpoint 추가
- membership: 480px/360px breakpoint 추가 (헤더 높이, 폰트 크기 축소)
- gallery: 480px 헤더 세로 정렬, 360px에서 1열 전환
- video: 360px breakpoint 추가