### PR TITLE
Feature/frontend

### DIFF
--- a/backend/templates/frontend/gallery.html
+++ b/backend/templates/frontend/gallery.html
@@ -61,10 +61,21 @@ body{background:var(--bg);color:var(--ink);font-family:Pretendard,'Apple SD Goth
 #lb-next{right:1rem;}
 #lb-info{position:absolute;bottom:1.5rem;left:50%;transform:translateX(-50%);font-family:'DM Mono',monospace;font-size:.55rem;letter-spacing:.16em;color:rgba(255,255,255,0.5);}
 
+/* FOOTER */
+.gl-footer{
+  border-top:.5px solid var(--bdr);
+  padding:2rem 2.5rem;
+  display:flex;justify-content:space-between;align-items:center;
+}
+.gl-footer-copy{font-family:'DM Mono',monospace;font-size:.52rem;letter-spacing:.1em;text-transform:uppercase;color:var(--dim);}
+.gl-footer-links{display:flex;gap:1.5rem;}
+.gl-footer-links a{font-family:'DM Mono',monospace;font-size:.52rem;letter-spacing:.1em;text-transform:uppercase;color:var(--dim);text-decoration:none;transition:color .2s;}
+.gl-footer-links a:hover{color:var(--acc);}
+
 /* MEDIA QUERIES */
 @media(max-width:1200px){.gl-grid{grid-template-columns:repeat(3,1fr);}}
 @media(max-width:768px){.gl-grid{grid-template-columns:repeat(2,1fr);padding:1.5rem;}.gl-header{flex-direction:column;gap:1.5rem;align-items:flex-start;}}
-@media(max-width:480px){.gl-grid{grid-template-columns:repeat(2,1fr);gap:.6rem;padding:1rem;}.gl-header{padding:2.5rem 1.2rem 1.5rem;flex-direction:column;gap:.8rem;align-items:flex-start;}.gl-nav{padding:0 1.2rem;height:56px;}}
+@media(max-width:480px){.gl-grid{grid-template-columns:repeat(2,1fr);gap:.6rem;padding:1rem;}.gl-header{padding:2.5rem 1.2rem 1.5rem;flex-direction:column;gap:.8rem;align-items:flex-start;}.gl-nav{padding:0 1.2rem;height:56px;}.gl-footer{flex-direction:column;gap:1rem;text-align:center;}}
 @media(max-width:360px){.gl-grid{grid-template-columns:1fr;}.gl-title{font-size:3.5rem;}}
 </style>
 </head>
@@ -171,6 +182,16 @@ body{background:var(--bg);color:var(--ink);font-family:Pretendard,'Apple SD Goth
   <button id="lb-next" onclick="lbNav(1)">&#8250;</button>
   <div id="lb-info"></div>
 </div>
+
+<!-- FOOTER -->
+<footer class="gl-footer">
+  <div class="gl-footer-copy">© 2026 Hari. All rights reserved.</div>
+  <div class="gl-footer-links">
+    <a href="/">홈으로</a>
+    <a href="/video/">비디오</a>
+    <a href="https://www.youtube.com/@Hari-o5m2r" target="_blank" rel="noopener">YouTube ↗</a>
+  </div>
+</footer>
 
 <script>
 const IMGS = [

--- a/backend/templates/frontend/includes/homepage/_nav_auth.html
+++ b/backend/templates/frontend/includes/homepage/_nav_auth.html
@@ -146,6 +146,11 @@
 
     <span class="nav-gnb-sep"></span>
 
+    <!-- 로컬 전용 관리자 링크 -->
+    {% if debug %}
+    <a href="/admin-panel/" style="font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif; font-size:.6rem; letter-spacing:.12em; text-transform:uppercase; color:var(--acc2); border:0.5px solid var(--acc2); padding:5px 12px; text-decoration:none; transition:background .2s; flex-shrink:0;" onmouseover="this.style.background='rgba(255,209,102,0.15)'" onmouseout="this.style.background='transparent'">Admin ⚙</a>
+    {% endif %}
+
     <!-- 내 정보 (로그인 시) -->
     {% if user.is_authenticated %}
     <div class="auth-user-wrap" id="user-menu-wrap">
@@ -163,11 +168,6 @@
     <!-- 로그인 (비로그인 시) -->
     {% if not user.is_authenticated %}
     <button id="auth-btn" onclick="openAuth('login')">로그인</button>
-    {% endif %}
-
-    <!-- 로컬 전용 관리자 링크 -->
-    {% if debug %}
-    <a href="/admin-panel/" style="font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif; font-size:.6rem; letter-spacing:.12em; text-transform:uppercase; color:var(--acc2); border:0.5px solid var(--acc2); padding:5px 12px; text-decoration:none; transition:background .2s; flex-shrink:0;" onmouseover="this.style.background='rgba(255,209,102,0.15)'" onmouseout="this.style.background='transparent'">Admin ⚙</a>
     {% endif %}
 
     <!-- 햄버거 메뉴 -->

--- a/backend/templates/frontend/includes/homepage/_s2_abouthari.html
+++ b/backend/templates/frontend/includes/homepage/_s2_abouthari.html
@@ -17,7 +17,7 @@
       <div class="profile-info-content">
         <div class="profile-name-row">
           <div class="profile-char-name">하리</div>
-          <a class="profile-more-link" href="/abouthari/">Discover More</a>
+          <a class="profile-more-link" href="/abouthari/">하리 더 알아보기</a>
         </div>
 
         <div class="profile-sns-row">

--- a/backend/templates/frontend/includes/homepage/_s4_video.html
+++ b/backend/templates/frontend/includes/homepage/_s4_video.html
@@ -145,7 +145,7 @@
 <section id="s4">
   <div class="s4-header">
     <h2 class="s4-title">VIDEOS</h2>
-    <a class="s4-more" href="/video/">VIEW ALL ↗</a>
+    <a class="s4-more" href="/video/">모두 보기 ↗</a>
   </div>
 
   <div class="premium-video-grid">

--- a/backend/templates/frontend/video.html
+++ b/backend/templates/frontend/video.html
@@ -35,19 +35,13 @@ body{background:var(--bg);color:var(--ink);font-family:Pretendard,'Apple SD Goth
   transition:background .3s;
 }
 .vd-nav-logo img{height:44px;width:auto;mix-blend-mode:multiply;display:block;}
-.vd-nav-right{display:flex;align-items:center;gap:1.5rem;}
-.vd-filter-group{display:flex;gap:.3rem;}
-.vd-filter-btn{
-  font-family:'DM Mono',monospace;font-size:.56rem;letter-spacing:.1em;
-  text-transform:uppercase;padding:5px 16px;
-  border:.5px solid var(--bdr2);background:transparent;
-  color:var(--dim);cursor:pointer;transition:all .2s;
-}
-.vd-filter-btn.on,.vd-filter-btn:hover{border-color:var(--acc);color:var(--acc);}
+.vd-nav-right{display:flex;align-items:center;}
 .vd-nav-back{
-  font-family:'DM Mono',monospace;font-size:.58rem;letter-spacing:.18em;
-  text-transform:uppercase;color:var(--dim);text-decoration:none;
+  font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;
+  font-size:1.1rem;font-weight:500;letter-spacing:-0.02em;
+  color:#6b6460;text-decoration:none;
   display:flex;align-items:center;gap:.5rem;transition:color .2s;
+  -webkit-font-smoothing:antialiased;
 }
 .vd-nav-back:hover{color:var(--acc);}
 .vd-nav-back:hover svg{transform:translateX(-3px);}
@@ -262,25 +256,11 @@ body{background:var(--bg);color:var(--ink);font-family:Pretendard,'Apple SD Goth
   <a class="vd-nav-logo" href="/">
     <img src="{% static 'images/hari_logo_none.png' %}?v=2" alt="HARI">
   </a>
-  <div class="vd-nav-right">
-    <div class="vd-filter-group" id="filter-group-nav">
-      <button class="vd-filter-btn on" id="btn-all" onclick="filterVideos('all',this)">All</button>
-      <button class="vd-filter-btn" id="btn-shorts" onclick="filterVideos('shorts',this)">Shorts</button>
-      <button class="vd-filter-btn" id="btn-full" onclick="filterVideos('full',this)">Videos</button>
-    </div>
-    <a class="vd-nav-back" href="/">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
-      홈으로
-    </a>
-  </div>
+  <a class="vd-nav-back" href="/">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+    홈으로
+  </a>
 </nav>
-
-<!-- MOBILE FILTER BAR -->
-<div class="vd-mobile-bar" id="filter-group-mobile">
-  <button class="vd-filter-btn on" onclick="filterVideos('all',this)">All</button>
-  <button class="vd-filter-btn" onclick="filterVideos('shorts',this)">Shorts</button>
-  <button class="vd-filter-btn" onclick="filterVideos('full',this)">Videos</button>
-</div>
 
 <!-- HEADER -->
 <div class="vd-header">
@@ -333,7 +313,7 @@ body{background:var(--bg);color:var(--ink);font-family:Pretendard,'Apple SD Goth
       </div>
       <div class="premium-vid-info">
         <div class="premium-vid-title">&lt;테크뉴스&gt; 구글 stitch의 변신</div>
-        <div class="premium-vid-meta">Review &amp; Update</div>
+        <div class="premium-vid-meta">Tech issue</div>
         <a class="premium-vid-link" href="https://www.youtube.com/shorts/LFBHDLvL2Yw" target="_blank" rel="noopener">
           <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 002.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg> YouTube 앱에서 보기 ↗
         </a>
@@ -351,7 +331,7 @@ body{background:var(--bg);color:var(--ink);font-family:Pretendard,'Apple SD Goth
       </div>
       <div class="premium-vid-info">
         <div class="premium-vid-title">&lt;테크뉴스&gt; 아무도 몰랐던 초파리 뇌의 비밀</div>
-        <div class="premium-vid-meta">Science Note</div>
+        <div class="premium-vid-meta">Tech issue</div>
         <a class="premium-vid-link" href="https://www.youtube.com/shorts/7Ytd-ZDlO0c" target="_blank" rel="noopener">
           <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 00-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.5A3 3 0 00.5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 002.1 2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z"></path></svg> YouTube 앱에서 보기 ↗
         </a>
@@ -368,7 +348,7 @@ body{background:var(--bg);color:var(--ink);font-family:Pretendard,'Apple SD Goth
 
 <!-- FOOTER -->
 <footer class="vd-footer">
-  <div class="vd-footer-copy">© 2025 Hari. All rights reserved.</div>
+  <div class="vd-footer-copy">© 2026 Hari. All rights reserved.</div>
   <div class="vd-footer-links">
     <a href="/">홈으로</a>
     <a href="/gallery/">갤러리</a>


### PR DESCRIPTION
feat(frontend): UI 통일성 개선 및 nav 정리

- gallery.html: video.html과 동일한 스타일의 하단 footer 추가
  (© 2026 Hari / 홈으로·비디오·YouTube 링크 / 모바일 세로 정렬 대응)

- video.html: 상단 nav '홈으로' 버튼 스타일을 gallery.html과 통일
  (DM Mono → Pretendard 1.1rem 500, SVG 14px → 18px)

- video.html: nav 및 모바일 필터바에서 All/Shorts/Videos 필터 버튼 제거
  (관련 CSS .vd-filter-group, .vd-filter-btn 함께 삭제)

- _nav_auth.html: 홈페이지 nav에서 Admin ⚙ / 로그인 버튼 순서 교체
  (Admin ⚙ → 로그인 순으로 변경)
