### PR TITLE
feat(auth): 회원가입·로그인 모달 UX 전면 개선

### DIFF
--- a/backend/templates/frontend/includes/homepage/_nav_auth.html
+++ b/backend/templates/frontend/includes/homepage/_nav_auth.html
@@ -112,6 +112,253 @@
   .nav-center { display: none !important; }
   .nav-right .nav-gnb-chat { display: none !important; }
 }
+
+/* ── AUTH MODAL 타이포그래피 개선 ── */
+#auth-modal {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  max-width: 460px !important;
+  padding: 2.8rem 2.8rem 2.2rem !important;
+  border-radius: 18px !important;
+  box-shadow: 0 24px 64px rgba(42,36,32,0.18) !important;
+}
+.auth-title {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  font-size: 2rem !important;
+  font-weight: 800 !important;
+  letter-spacing: -0.04em !important;
+  color: var(--ink) !important;
+  line-height: 1.15 !important;
+  margin-bottom: 0.3rem !important;
+}
+.auth-sub {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  font-size: 0.95rem !important;
+  line-height: 1.7 !important;
+  color: var(--dim) !important;
+  margin-bottom: 0.6rem !important;
+  font-weight: 400 !important;
+}
+.auth-tabs {
+  margin-bottom: 1.8rem !important;
+  border-bottom: 1.5px solid var(--bdr) !important;
+}
+.auth-tab {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  font-size: 0.88rem !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.01em !important;
+  padding: 0.75rem 0 !important;
+  margin-right: 2rem !important;
+  text-transform: none !important;
+  color: var(--dim) !important;
+}
+.auth-tab.on {
+  color: var(--ink) !important;
+  border-bottom: 2px solid var(--acc) !important;
+}
+.auth-label {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  font-size: 0.78rem !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.01em !important;
+  text-transform: none !important;
+  color: var(--ink) !important;
+  margin-bottom: 0.35rem !important;
+}
+.auth-inp {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  font-size: 0.97rem !important;
+  padding: 0.82rem 1rem !important;
+  border-radius: 10px !important;
+  border: 1.5px solid var(--bdr) !important;
+  transition: border-color 0.2s, box-shadow 0.2s !important;
+}
+.auth-inp:focus {
+  border-color: var(--acc) !important;
+  box-shadow: 0 0 0 3px rgba(255,123,138,0.12) !important;
+  outline: none !important;
+}
+.auth-inp::placeholder { color: #c4bcb8 !important; }
+.social-btn {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  font-size: 0.87rem !important;
+  font-weight: 500 !important;
+  padding: 0.78rem 0.7rem !important;
+  border-radius: 10px !important;
+  border: 1.5px solid var(--bdr) !important;
+  gap: 8px !important;
+  transition: border-color 0.2s, background 0.2s, box-shadow 0.2s !important;
+}
+.social-btn:hover {
+  border-color: var(--acc) !important;
+  box-shadow: 0 2px 8px rgba(255,123,138,0.1) !important;
+}
+.auth-divider {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  font-size: 0.78rem !important;
+  font-weight: 500 !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+  color: var(--dim) !important;
+}
+.auth-submit {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  font-size: 1rem !important;
+  font-weight: 700 !important;
+  letter-spacing: -0.01em !important;
+  text-transform: none !important;
+  padding: 0.9rem !important;
+  border-radius: 12px !important;
+  background: var(--acc) !important;
+  transition: background 0.2s, transform 0.1s, box-shadow 0.2s !important;
+  box-shadow: 0 4px 14px rgba(255,123,138,0.35) !important;
+}
+.auth-submit:hover {
+  background: #ff5c6e !important;
+  box-shadow: 0 6px 20px rgba(255,123,138,0.45) !important;
+}
+.auth-submit:active { transform: scale(0.97) !important; }
+.auth-switch {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  font-size: 0.85rem !important;
+  color: var(--dim) !important;
+  text-align: center !important;
+}
+.auth-switch button {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  font-size: 0.85rem !important;
+  font-weight: 600 !important;
+  color: var(--acc) !important;
+  border-bottom: 1px solid var(--acc) !important;
+}
+.auth-check {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  font-size: 0.84rem !important;
+  line-height: 1.6 !important;
+  color: var(--dim) !important;
+}
+.auth-forgot {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif !important;
+  font-size: 0.82rem !important;
+  font-weight: 500 !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+}
+.auth-check .terms-link {
+  color: var(--acc) !important;
+  font-weight: 600 !important;
+  text-decoration: none !important;
+  border: none !important;
+  border-bottom: 1px solid rgba(255,123,138,0.4) !important;
+  cursor: pointer !important;
+  background: none !important;
+  padding: 0 !important;
+  font-size: 0.84rem !important;
+  font-family: inherit !important;
+  transition: color 0.18s !important;
+  outline: none !important;
+  display: inline !important;
+  line-height: inherit !important;
+}
+.auth-check .terms-link:hover { color: #ff4c6c !important; }
+
+/* ── 이메일 유효성 피드백 ── */
+.auth-inp.inp-valid {
+  border-color: #22c55e !important;
+  box-shadow: 0 0 0 3px rgba(34,197,94,0.1) !important;
+}
+.auth-inp.inp-invalid {
+  border-color: #ff4c6c !important;
+  box-shadow: 0 0 0 3px rgba(255,76,108,0.1) !important;
+}
+.email-feedback {
+  display: flex; align-items: center; gap: 5px;
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;
+  font-size: 0.77rem; font-weight: 500;
+  margin-top: 6px; min-height: 18px;
+  transition: opacity 0.2s;
+}
+.email-feedback.valid { color: #16a34a; }
+.email-feedback.invalid { color: #ff4c6c; }
+.email-feedback .fb-icon { font-size: 0.82rem; }
+
+/* ── 이용약관 / 개인정보 처리방침 모달 ── */
+#terms-overlay, #privacy-overlay {
+  position: fixed; inset: 0; z-index: 700;
+  background: rgba(42,36,32,0.55);
+  backdrop-filter: blur(8px);
+  display: flex; align-items: center; justify-content: center;
+  padding: 1.5rem;
+  opacity: 0; pointer-events: none;
+  transition: opacity 0.3s;
+}
+#terms-overlay.show, #privacy-overlay.show { opacity: 1; pointer-events: all; }
+.legal-modal {
+  background: #fff;
+  border-radius: 20px;
+  width: 100%; max-width: 560px;
+  max-height: 80vh;
+  display: flex; flex-direction: column;
+  box-shadow: 0 24px 64px rgba(42,36,32,0.2);
+  transform: translateY(20px);
+  transition: transform 0.35s cubic-bezier(.77,0,.18,1);
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;
+}
+#terms-overlay.show .legal-modal,
+#privacy-overlay.show .legal-modal { transform: translateY(0); }
+.legal-modal-head {
+  padding: 1.8rem 2rem 1.2rem;
+  border-bottom: 1px solid var(--bdr);
+  display: flex; align-items: center; justify-content: space-between;
+  flex-shrink: 0;
+}
+.legal-modal-title {
+  font-size: 1.3rem; font-weight: 800;
+  letter-spacing: -0.03em; color: var(--ink);
+}
+.legal-modal-date {
+  font-size: 0.72rem; color: var(--dim); margin-top: 0.2rem;
+}
+.legal-close-btn {
+  background: transparent; border: none; cursor: pointer;
+  width: 32px; height: 32px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--dim); font-size: 1.1rem;
+  transition: background 0.18s, color 0.18s;
+}
+.legal-close-btn:hover { background: rgba(255,123,138,0.08); color: var(--acc); }
+.legal-modal-body {
+  padding: 1.6rem 2rem 2rem;
+  overflow-y: auto;
+  flex: 1;
+  line-height: 1.85;
+  font-size: 0.88rem;
+  color: #4a4440;
+}
+.legal-modal-body h3 {
+  font-size: 0.98rem; font-weight: 700;
+  color: var(--ink); margin: 1.4rem 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+.legal-modal-body h3:first-child { margin-top: 0; }
+.legal-modal-body p { margin-bottom: 0.6rem; }
+.legal-modal-body ul { padding-left: 1.3rem; margin-bottom: 0.6rem; }
+.legal-modal-body ul li { margin-bottom: 0.3rem; }
+.legal-modal-foot {
+  padding: 1rem 2rem;
+  border-top: 1px solid var(--bdr);
+  display: flex; justify-content: flex-end;
+  flex-shrink: 0;
+}
+.legal-confirm-btn {
+  font-family: Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;
+  font-size: 0.9rem; font-weight: 700;
+  background: var(--acc); color: #fff;
+  border: none; border-radius: 10px;
+  padding: 0.68rem 2rem; cursor: pointer;
+  transition: background 0.2s;
+}
+.legal-confirm-btn:hover { background: #ff5c6e; }
 </style>
 
 <nav id="nav">
@@ -331,7 +578,11 @@
       </div>
       <div class="auth-field">
         <label class="auth-label" for="signupEmail">이메일</label>
-        <input class="auth-inp" id="signupEmail" name="signupEmail" type="email" placeholder="hello@hari.kr">
+        <input class="auth-inp" id="signupEmail" name="signupEmail" type="email"
+          placeholder="hello@hari.kr"
+          oninput="validateSignupEmail(this)"
+          onblur="validateSignupEmail(this, true)">
+        <div class="email-feedback" id="email-feedback"></div>
       </div>
       <div class="auth-field">
         <label class="auth-label" for="signup-pw">비밀번호</label>
@@ -348,7 +599,7 @@
 
       <label class="auth-check" for="signup-terms">
         <input type="checkbox" id="signup-terms" name="signup-terms" required>
-        <a href="#" onclick="closeAuth()">이용약관</a> 및 <a href="#" onclick="closeAuth()">개인정보처리방침</a>에 동의합니다.
+        <button type="button" class="terms-link" onclick="openTerms()">이용약관</button> 및 <button type="button" class="terms-link" onclick="openPrivacy()">개인정보처리방침</button>에 동의합니다.
       </label>
       <label class="auth-check" for="signup-news">
         <input type="checkbox" id="signup-news" name="signup-news">
@@ -382,3 +633,254 @@
     <span><em>✦</em>HARI ARTIST</span><span><em>✦</em>하리 공식 팬클럽</span><span><em>✦</em>FASHION × MUSIC × CULTURE</span><span><em>✦</em>SEOUL · GLOBAL</span><span><em>✦</em>NEW SINGLE OUT NOW</span><span><em>✦</em>CHAT WITH HARI</span>
   </div>
 </div>
+
+<!-- ── 이용약관 모달 ── -->
+<div id="terms-overlay" onclick="termsOverlayClose(event)">
+  <div class="legal-modal">
+    <div class="legal-modal-head">
+      <div>
+        <div class="legal-modal-title">이용약관</div>
+        <div class="legal-modal-date">시행일: 2026년 1월 1일 · 최종 개정: 2026년 4월 1일</div>
+      </div>
+      <button class="legal-close-btn" onclick="closeTerms()">✕</button>
+    </div>
+    <div class="legal-modal-body">
+      <h3>제1조 (목적)</h3>
+      <p>이 약관은 HARI 팬클럽 플랫폼(이하 "서비스")이 제공하는 모든 서비스의 이용 조건 및 절차, 이용자와 서비스 간의 권리·의무 및 책임사항을 규정함을 목적으로 합니다.</p>
+
+      <h3>제2조 (정의)</h3>
+      <ul>
+        <li><strong>"서비스"</strong>란 HARI 팬클럽이 운영하는 웹사이트 및 관련 서비스 전체를 말합니다.</li>
+        <li><strong>"이용자"</strong>란 서비스에 접속하여 이 약관에 따라 서비스를 이용하는 회원 및 비회원을 말합니다.</li>
+        <li><strong>"회원"</strong>이란 서비스에 개인정보를 제공하여 회원 등록을 한 자로, 서비스를 지속적으로 이용할 수 있는 자를 말합니다.</li>
+        <li><strong>"멤버십"</strong>이란 유료로 제공되는 프리미엄 서비스 플랜을 말합니다.</li>
+      </ul>
+
+      <h3>제3조 (약관의 효력 및 변경)</h3>
+      <p>본 약관은 서비스 화면에 게시하거나 기타의 방법으로 이용자에게 공지함으로써 효력이 발생합니다. 서비스는 필요한 경우 약관을 변경할 수 있으며, 변경된 약관은 공지 후 7일 이후부터 효력이 발생합니다.</p>
+
+      <h3>제4조 (회원가입)</h3>
+      <ul>
+        <li>이용자는 서비스가 정한 양식에 따라 정보를 기입한 후 본 약관에 동의함으로써 회원가입을 신청합니다.</li>
+        <li>만 14세 미만 이용자는 회원가입이 제한될 수 있습니다.</li>
+        <li>타인의 정보를 도용하거나 허위 정보를 기재한 경우 서비스 이용이 제한될 수 있습니다.</li>
+      </ul>
+
+      <h3>제5조 (서비스 이용)</h3>
+      <p>서비스는 연중무휴, 1일 24시간 제공함을 원칙으로 합니다. 단, 정기 점검이나 기술적 문제로 서비스가 일시 중지될 수 있으며, 이 경우 사전에 공지합니다.</p>
+
+      <h3>제6조 (이용자의 의무)</h3>
+      <ul>
+        <li>타인의 개인정보를 도용하거나 허위 정보를 등록하는 행위</li>
+        <li>서비스에서 얻은 정보를 무단으로 복제·배포하는 행위</li>
+        <li>다른 이용자를 비방하거나 명예를 훼손하는 행위</li>
+        <li>서비스의 정상적인 운영을 방해하는 행위</li>
+      </ul>
+      <p>위 사항을 위반할 경우 사전 통보 없이 회원자격이 박탈될 수 있습니다.</p>
+
+      <h3>제7조 (멤버십 및 환불)</h3>
+      <p>유료 멤버십은 결제일로부터 구독 기간이 시작되며, 구독 중 취소 시 다음 결제일까지 서비스 이용이 가능합니다. 단순 변심에 의한 환불은 결제 후 7일 이내에만 가능하며, 콘텐츠를 이미 이용한 경우 환불이 제한될 수 있습니다.</p>
+
+      <h3>제8조 (면책조항)</h3>
+      <p>서비스는 천재지변, 불가항력적 사유로 인한 서비스 중단에 대해 책임을 지지 않습니다. 이용자가 게시한 콘텐츠에 대한 책임은 해당 이용자에게 있습니다.</p>
+
+      <h3>제9조 (준거법 및 관할)</h3>
+      <p>본 약관은 대한민국 법률에 따라 해석되며, 서비스 이용과 관련된 분쟁은 대한민국 법원을 전속 관할로 합니다.</p>
+    </div>
+    <div class="legal-modal-foot">
+      <button class="legal-confirm-btn" onclick="closeTerms()">확인했습니다 ✓</button>
+    </div>
+  </div>
+</div>
+
+<!-- ── 개인정보처리방침 모달 ── -->
+<div id="privacy-overlay" onclick="privacyOverlayClose(event)">
+  <div class="legal-modal">
+    <div class="legal-modal-head">
+      <div>
+        <div class="legal-modal-title">개인정보처리방침</div>
+        <div class="legal-modal-date">시행일: 2026년 1월 1일 · 최종 개정: 2026년 4월 1일</div>
+      </div>
+      <button class="legal-close-btn" onclick="closePrivacy()">✕</button>
+    </div>
+    <div class="legal-modal-body">
+      <h3>1. 수집하는 개인정보 항목</h3>
+      <p>HARI 팬클럽은 회원가입 및 서비스 제공을 위해 아래와 같은 개인정보를 수집합니다.</p>
+      <ul>
+        <li><strong>필수 항목:</strong> 이메일 주소, 닉네임, 비밀번호(암호화 저장)</li>
+        <li><strong>소셜 로그인 시:</strong> 소셜 계정 고유 ID, 프로필 이름 (비밀번호 미수집)</li>
+        <li><strong>서비스 이용 중 자동 수집:</strong> 접속 IP, 브라우저 정보, 쿠키, 서비스 이용 기록</li>
+      </ul>
+
+      <h3>2. 개인정보 수집 및 이용 목적</h3>
+      <ul>
+        <li>회원 가입 및 본인 확인</li>
+        <li>서비스 제공 및 콘텐츠 맞춤화</li>
+        <li>멤버십 결제 및 고객 지원</li>
+        <li>서비스 개선 및 신규 기능 개발</li>
+        <li>이벤트·공지사항·뉴스레터 발송 (선택 동의 시)</li>
+      </ul>
+
+      <h3>3. 개인정보 보유 및 이용 기간</h3>
+      <p>수집된 개인정보는 회원 탈퇴 시 즉시 파기합니다. 단, 관련 법령에 따라 일정 기간 보관이 필요한 경우 아래와 같이 보유합니다.</p>
+      <ul>
+        <li>전자상거래 기록: 5년 (전자상거래법)</li>
+        <li>접속 로그: 3개월 (통신비밀보호법)</li>
+      </ul>
+
+      <h3>4. 개인정보의 제3자 제공</h3>
+      <p>HARI 팬클럽은 원칙적으로 이용자의 개인정보를 외부에 제공하지 않습니다. 단, 이용자가 사전에 동의한 경우 또는 법령에 따른 요청이 있는 경우에는 예외로 합니다.</p>
+
+      <h3>5. 개인정보 처리 위탁</h3>
+      <ul>
+        <li><strong>결제 처리:</strong> 토스페이먼츠 — 결제 정보 처리 및 환불</li>
+        <li><strong>클라우드 인프라:</strong> Amazon Web Services — 데이터 저장 및 서버 운영</li>
+        <li><strong>소셜 로그인:</strong> Google, Naver — 본인 인증</li>
+      </ul>
+
+      <h3>6. 이용자의 권리</h3>
+      <p>이용자는 언제든지 자신의 개인정보를 조회·수정·삭제할 수 있으며, 마이페이지 또는 고객센터를 통해 요청하실 수 있습니다. 개인정보 처리에 관한 동의를 철회하고자 할 경우 회원 탈퇴를 통해 처리됩니다.</p>
+
+      <h3>7. 쿠키 정책</h3>
+      <p>서비스는 이용자 편의를 위해 쿠키를 사용합니다. 브라우저 설정에서 쿠키 허용을 거부할 수 있으나, 일부 서비스 기능이 제한될 수 있습니다.</p>
+
+      <h3>8. 개인정보 보호책임자</h3>
+      <ul>
+        <li><strong>책임자:</strong> HARI 팬클럽 운영팀</li>
+        <li><strong>이메일:</strong> privacy@hari.kr</li>
+        <li><strong>처리 기간:</strong> 접수 후 영업일 3일 이내</li>
+      </ul>
+    </div>
+    <div class="legal-modal-foot">
+      <button class="legal-confirm-btn" onclick="closePrivacy()">확인했습니다 ✓</button>
+    </div>
+  </div>
+</div>
+
+<script>
+function openTerms(){
+  document.getElementById('terms-overlay').classList.add('show');
+  document.body.style.overflow = 'hidden';
+}
+function closeTerms(){
+  document.getElementById('terms-overlay').classList.remove('show');
+  document.body.style.overflow = '';
+}
+function termsOverlayClose(e){
+  if(e.target === document.getElementById('terms-overlay')) closeTerms();
+}
+function openPrivacy(){
+  document.getElementById('privacy-overlay').classList.add('show');
+  document.body.style.overflow = 'hidden';
+}
+function closePrivacy(){
+  document.getElementById('privacy-overlay').classList.remove('show');
+  document.body.style.overflow = '';
+}
+function privacyOverlayClose(e){
+  if(e.target === document.getElementById('privacy-overlay')) closePrivacy();
+}
+document.addEventListener('keydown', function(e){
+  if(e.key === 'Escape'){
+    closeTerms();
+    closePrivacy();
+  }
+});
+
+/* ── 이메일 유효성 검사 ── */
+const DISPOSABLE_DOMAINS = [
+  'mailinator.com','guerrillamail.com','tempmail.com','throwaway.email',
+  'yopmail.com','sharklasers.com','guerrillamailblock.com','grr.la',
+  'guerrillamail.info','grr.la','spam4.me','trashmail.com','trashmail.me',
+  'trashmail.at','trashmail.io','fakeinbox.com','tempinbox.com','maildrop.cc',
+  'dispostable.com','mailnull.com','spamgourmet.com','spamgourmet.net',
+  'spamgourmet.org','discard.email','mailnesia.com','mail-temp.com',
+  'temp-mail.org','temp-mail.io','moakt.com','mohmal.com','getairmail.com',
+  'filzmail.com','throwam.com','dispostable.com','spamhereplease.com',
+  'nada.email','crazymailing.com','mytemp.email','trbvm.com','emlpro.com',
+  'inboxbear.com','mytrashmailer.com','tempemailer.com','emailondeck.com'
+];
+
+function isRealEmailFormat(email) {
+  // 엄격한 이메일 정규식
+  const re = /^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/;
+  if (!re.test(email)) return false;
+  const parts = email.split('@');
+  const local = parts[0], domain = parts[1];
+  // 연속 점 금지
+  if (/\.{2,}/.test(email)) return false;
+  // 점으로 시작/끝 금지
+  if (local.startsWith('.') || local.endsWith('.')) return false;
+  // 도메인 최소 구조 (xxx.xx)
+  const domainParts = domain.split('.');
+  if (domainParts.length < 2) return false;
+  if (domainParts.some(p => p.length === 0)) return false;
+  // TLD 2자 이상
+  if (domainParts[domainParts.length - 1].length < 2) return false;
+  return true;
+}
+
+function isDisposableDomain(email) {
+  const domain = email.split('@')[1] ? email.split('@')[1].toLowerCase() : '';
+  return DISPOSABLE_DOMAINS.includes(domain);
+}
+
+const TRUSTED_DOMAINS = [
+  'gmail.com','naver.com','kakao.com','daum.net','hanmail.net',
+  'nate.com','yahoo.com','outlook.com','hotmail.com','icloud.com',
+  'me.com','protonmail.com','proton.me','live.com','msn.com',
+  'korea.ac.kr','snu.ac.kr','yonsei.ac.kr','kaist.ac.kr'
+];
+
+function validateSignupEmail(input, isFinal) {
+  const fb = document.getElementById('email-feedback');
+  const val = input.value.trim();
+
+  if (!val) {
+    input.classList.remove('inp-valid','inp-invalid');
+    fb.innerHTML = ''; fb.className = 'email-feedback';
+    return;
+  }
+
+  if (!isRealEmailFormat(val)) {
+    input.classList.remove('inp-valid'); input.classList.add('inp-invalid');
+    fb.className = 'email-feedback invalid';
+    fb.innerHTML = '<span class="fb-icon">✕</span> 올바른 이메일 형식이 아닙니다.';
+    return;
+  }
+
+  if (isDisposableDomain(val)) {
+    input.classList.remove('inp-valid'); input.classList.add('inp-invalid');
+    fb.className = 'email-feedback invalid';
+    fb.innerHTML = '<span class="fb-icon">✕</span> 임시 이메일 주소는 사용할 수 없습니다.';
+    return;
+  }
+
+  // 형식 OK
+  input.classList.remove('inp-invalid'); input.classList.add('inp-valid');
+  const domain = val.split('@')[1].toLowerCase();
+  const isTrusted = TRUSTED_DOMAINS.includes(domain);
+  fb.className = 'email-feedback valid';
+  fb.innerHTML = isTrusted
+    ? '<span class="fb-icon">✓</span> 이메일 주소가 확인되었습니다.'
+    : '<span class="fb-icon">✓</span> 형식이 올바릅니다.';
+}
+
+// doSignup 가로채기 — 이메일 검증 통과 후에만 진행
+const _origDoSignup = window.doSignup;
+window.doSignup = function() {
+  const emailInp = document.getElementById('signupEmail');
+  const val = emailInp ? emailInp.value.trim() : '';
+  if (!isRealEmailFormat(val)) {
+    validateSignupEmail(emailInp, true);
+    emailInp.focus();
+    return;
+  }
+  if (isDisposableDomain(val)) {
+    validateSignupEmail(emailInp, true);
+    emailInp.focus();
+    return;
+  }
+  if (typeof _origDoSignup === 'function') _origDoSignup();
+};
+</script>


### PR DESCRIPTION
- _nav_auth.html: 모달 전체 타이포그래피 Pretendard 폰트로 통일 · auth-title 2rem/800, auth-sub 0.95rem, auth-tab 0.88rem/600 · auth-inp 0.97rem + 포커스 시 핑크 glow 효과 · auth-submit 1rem/700 + 그림자 + hover 애니메이션 · auth-label, social-btn, auth-check 등 전체 폰트 사이즈 확대

- _nav_auth.html: 이용약관 / 개인정보처리방침 모달 신규 추가 · 슬라이드 인 애니메이션, 스크롤 가능한 본문 영역 · 이용약관 9개조, 개인정보처리방침 8개항 내용 포함 · ESC 키 / 배경 클릭으로 닫기 지원

- _nav_auth.html: 약관 링크 검은 박스(border) 제거 · terms-link button에 border: none + outline: none 적용 · 핑크 밑줄(border-bottom)만 유지

- _nav_auth.html: 회원가입 이메일 실시간 유효성 검사 추가 · 엄격한 정규식 + 연속 점·점 시작/끝 금지 검증 · 일회용 이메일 도메인 40개+ 차단 (mailinator, tempmail 등) · 신뢰 도메인(gmail, naver, kakao 등) 입력 시 확인 메시지 표시 · 검증 실패 시 가입하기 버튼 진행 차단 + 필드 포커스 이동 · 입력창 초록/빨강 테두리 피드백 UI