### PR TITLE
fix(deploy): EB 배포 타임아웃 600초 → 1200초로 연장

### DIFF
--- a/backend/.ebextensions/00_port.config
+++ b/backend/.ebextensions/00_port.config
@@ -1,0 +1,5 @@
+option_settings:
+  aws:elasticbeanstalk:command:
+    Timeout: 1200
+  aws:elasticbeanstalk:healthreporting:system:
+    HealthCheckSuccessThreshold: Ok


### PR DESCRIPTION
- .ebextensions/00_port.config 신규 추가 · Timeout: 1200 설정 (기본 600초에서 20분으로 연장) · 원인: chromadb, langchain, kss 등 무거운 패키지로 인해 EC2 인스턴스에서 Docker 빌드 시 10분 초과 → EB 타임아웃 배포 실패 · Docker 레이어 캐시 미존재 시 전체 pip install 재수행으로 기본 타임아웃 초과 가능성 존재