### PR TITLE
Fix: Docker 빌드 타임아웃 해결 (배포 실패 수정)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,9 @@
       "Bash(aws sts:*)",
       "Bash(nslookup:*)",
       "Bash(curl -sS -v https://chatting-hari.com/)",
-      "Bash(aws elbv2 describe-load-balancers:*)"
+      "Bash(aws elbv2 describe-load-balancers:*)",
+      "Bash(chmod +x c:/Workspaces/SKN22-Final-4Team-WEB/backend/.platform/hooks/prebuild/01-docker-build.sh)",
+      "Bash(git update-index:*)"
     ]
   }
 }

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -9,3 +9,6 @@ __pycache__/
 .git/
 .gitignore
 *.log
+
+# Exclude large media files from build context (89MB+ savings)
+static/video/

--- a/backend/.platform/hooks/prebuild/01-docker-build.sh
+++ b/backend/.platform/hooks/prebuild/01-docker-build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Pre-build Docker images before EB's 300s timeout build step
+# This hook runs without the 300s limit, so large builds can complete
+cd /var/app/staging
+docker compose build --parallel 2>&1 | tee /var/log/docker-prebuild.log


### PR DESCRIPTION
- .dockerignore에 static/video/ 추가 (빌드 컨텍스트 89MB 감소)
- prebuild hook 추가로 300초 타임아웃 우회