### PR TITLE
Fix: FirstMessage 한국어 문법 오류 수정

### DIFF
--- a/backend/roleplay/consumers.py
+++ b/backend/roleplay/consumers.py
@@ -3,6 +3,7 @@ from channels.generic.websocket import AsyncWebsocketConsumer
 from asgiref.sync import sync_to_async
 from .models import RpgSession
 from .engine import MainEngine, apply_status_metadata_to_session, extract_status_metadata, strip_status_content
+from .korean_text import render_user_template
 
 class RoleplayConsumer(AsyncWebsocketConsumer):
     async def connect(self):
@@ -75,8 +76,7 @@ class RoleplayConsumer(AsyncWebsocketConsumer):
         if first_ms_lore:
             content = first_ms_lore.lorebook
         
-        content = content.replace('{{user}}', session.user_nickname)
-        content = content.replace('{{User}}', session.user_nickname)
+        content = render_user_template(content, session.user_nickname)
         status_snapshot = extract_status_metadata(content)
         visible_content = strip_status_content(content)
         apply_status_metadata_to_session(session, status_snapshot)

--- a/backend/roleplay/engine.py
+++ b/backend/roleplay/engine.py
@@ -5,6 +5,7 @@ from django.template import Template, Context
 from django.conf import settings
 from django.utils import timezone
 from .models import RpgSession, RpgChatLog, RpgHyperMemory, RpgLorebook
+from .korean_text import build_user_placeholder_context
 
 
 def _extract_meta_value(source_text: str, label: str) -> str:
@@ -161,6 +162,21 @@ class PromptBuilder:
         text = text.replace('{{/if_pure}}', '{% endif %}')
         return text
 
+    def _build_template_context(self, kwargs: dict) -> dict:
+        status_toggle = 1 if self.session.status_window_enabled else 0
+        context_dict = build_user_placeholder_context(self.session.user_nickname)
+        context_dict.update({
+            'toggle_status_window': status_toggle,
+            'toggle_perspective': kwargs.get('perspective', 1),
+            'toggle_impersonation': kwargs.get('impersonation', 1),
+            'toggle_attempt': kwargs.get('attempt', 0),
+            'toggle_input_impersonation': kwargs.get('input_impersonation', 0),
+        })
+        return context_dict
+
+    def _render_template_text(self, text: str, kwargs: dict) -> str:
+        return Template(text).render(Context(self._build_template_context(kwargs)))
+
     def build_system_prompt(self, kwargs: dict) -> str:
         """
         Loads the rule markdown, converts macros to Django templating, 
@@ -172,6 +188,7 @@ class PromptBuilder:
 
         raw_text = self.rule_file_path.read_text(encoding='utf-8')
         django_template_str = self._convert_risu_to_django_template(raw_text)
+        return self._render_template_text(django_template_str, kwargs)
         
         t = Template(django_template_str)
         
@@ -201,6 +218,8 @@ class PromptBuilder:
         # Assuming higher priority number means it should be injected closer to the end, or just grouped.
         lorebooks = RpgLorebook.objects.filter(is_active=True).order_by('priority').values_list('lorebook', flat=True)
         prologue_text = "\n\n".join(lorebooks)
+        rendered_lorebooks = [self._render_template_text(lorebook, kwargs) for lorebook in lorebooks]
+        prologue_text = "\n\n".join(rendered_lorebooks)
         
         # 3. Past Records (HyperMemory)
         # Fetch latest hyper memory for the session

--- a/backend/roleplay/korean_text.py
+++ b/backend/roleplay/korean_text.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from django.template import Context, Template
+
+
+def has_final_consonant(text: str) -> bool:
+    cleaned = (text or "").strip()
+    if not cleaned:
+        return False
+
+    last_char = cleaned[-1]
+    code = ord(last_char)
+    if 0xAC00 <= code <= 0xD7A3:
+        return (code - 0xAC00) % 28 != 0
+
+    return False
+
+
+def attach_josa(text: str, with_batchim: str, without_batchim: str) -> str:
+    return f"{text}{with_batchim if has_final_consonant(text) else without_batchim}"
+
+
+def build_user_placeholder_context(nickname: str) -> dict[str, str]:
+    return {
+        "user": nickname,
+        "User": nickname,
+        "user_nickname": nickname,
+        "user_subj": attach_josa(nickname, "이", "가"),
+        "user_obj": attach_josa(nickname, "을", "를"),
+        "user_topic": attach_josa(nickname, "은", "는"),
+        "user_with": attach_josa(nickname, "과", "와"),
+        "user_and": attach_josa(nickname, "이랑", "랑"),
+    }
+
+
+def render_user_template(text: str, nickname: str, extra_context: dict | None = None) -> str:
+    context = build_user_placeholder_context(nickname)
+    if extra_context:
+        context.update(extra_context)
+
+    return Template(text).render(Context(context))


### PR DESCRIPTION
## 주요 변경 사항

### 백엔드
- `{{user}}` 외에 조사형 플레이스홀더 지원 추가
  - `{{user_subj}}`, `{{user_obj}}`, `{{user_topic}}`, `{{user_with}}`, `{{user_and}}`

## 참고
- 자연스러운 출력이 필요하면 아래 플레이스홀더를 사용해야 합니다.
  - {{user}} / {{User}} / {{user_nickname}}
  - {{user_subj}} → 민제가, 준석이가
  - {{user_obj}} → 민제를, 준석을
  - {{user_topic}} → 민제는, 준석은
  - {{user_with}} → 민제와, 준석과
  - {{user_and}} → 민제랑, 준석이랑
