### PR TITLE
Feat: Django 어드민 패널 프론트엔드 전체 구축, 프론트엔드 테스트를 위한 회원가입 검증 임시 처리

### DIFF
--- a/BACKEND_REQUEST.md
+++ b/BACKEND_REQUEST.md
@@ -242,3 +242,267 @@ class UserMembership(models.Model):
    - 인증 필수, CSRF 토큰 필수
    - 성공 응답: `{"success": true, "message": "구독이 취소되었습니다."}`
    - 오류 응답: `{"success": false, "error": "구독 정보가 없습니다."}`
+
+---
+
+## 📅 2026-04-13 (일) — /admin/ 관리자 페이지 기능 확장
+
+> 프론트엔드가 `/admin/` (Django admin) 커스텀 템플릿을 모두 구축했습니다.  
+> 아래 항목은 백엔드 모델·뷰가 없어 **현재 admin에서 placeholder만 표시** 중인 기능입니다.  
+> 구현 순서는 우선순위 순으로 정렬했습니다.
+
+---
+
+### [우선순위 1] 관리자 대시보드 KPI 컨텍스트 — `/admin/`
+
+Django admin의 `index.html` 템플릿은 현재 `app_list`와 `recent_actions`만 받습니다.  
+대시보드에 실시간 통계를 표시하려면 `AdminSite.index()` 뷰를 오버라이드해서 아래 변수를 추가해야 합니다.
+
+**백엔드 작업:**
+
+`config/urls.py` 또는 별도 파일에 커스텀 AdminSite 클래스 추가:
+
+```python
+from django.contrib.admin import AdminSite
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from chat.models import Message, VisitLog
+
+class HariAdminSite(AdminSite):
+    def index(self, request, extra_context=None):
+        today = timezone.now().date()
+        User = get_user_model()
+        extra_context = extra_context or {}
+        extra_context.update({
+            'kpi_new_users_today':    User.objects.filter(date_joined__date=today).count(),
+            'kpi_chat_count_today':   Message.objects.filter(created_at__date=today, sender_type=True).count(),
+            'kpi_total_users':        User.objects.count(),
+            'kpi_today_visits':       VisitLog.objects.filter(visit_time__date=today).count(),
+        })
+        return super().index(request, extra_context)
+
+admin_site = HariAdminSite(name='admin')
+```
+
+| 변수명 | 설명 |
+|---|---|
+| `kpi_new_users_today` | 오늘 신규 가입자 수 |
+| `kpi_chat_count_today` | 오늘 채팅 메시지 수 (유저 발신) |
+| `kpi_total_users` | 전체 유저 수 |
+| `kpi_today_visits` | 오늘 방문 수 |
+
+---
+
+### [우선순위 2] 롤플레잉 시나리오 버전 히스토리 모델
+
+**현재 상황:** Lorebook 편집 시 이전 버전으로 롤백 불가  
+**프론트 준비:** 편집 폼에 버전 히스토리 UI 공간 확보됨 (백엔드 연결만 필요)
+
+**백엔드 작업:** `rpg/models.py`에 추가 (기존 모델 수정 없이 새 모델만 추가)
+
+```python
+class LorebookVersion(models.Model):
+    lorebook = models.ForeignKey(
+        'Lorebook', on_delete=models.CASCADE, related_name='versions'
+    )
+    lorebook_text = models.TextField(help_text="저장 시점의 lorebook 내용")
+    keywords_snapshot = models.JSONField(help_text="저장 시점의 keywords")
+    version_number = models.PositiveIntegerField()
+    saved_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL,
+        null=True, blank=True
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'rpg_lorebook_versions'
+        ordering = ['-version_number']
+
+    def __str__(self):
+        return f"Lorebook({self.lorebook_id}) v{self.version_number}"
+```
+
+**추가 요청 (admin.py):** Lorebook 저장 시 자동 버전 생성 signal 또는 `save_model()` 오버라이드
+
+```python
+# rpg/admin.py — LorebookAdmin에 추가
+def save_model(self, request, obj, form, change):
+    super().save_model(request, obj, form, change)
+    if change:  # 수정 시에만
+        last_v = LorebookVersion.objects.filter(lorebook=obj).order_by('-version_number').first()
+        next_v = (last_v.version_number + 1) if last_v else 1
+        LorebookVersion.objects.create(
+            lorebook=obj,
+            lorebook_text=obj.lorebook,
+            keywords_snapshot=obj.keywords,
+            version_number=next_v,
+            saved_by=request.user,
+        )
+```
+
+---
+
+### [우선순위 3] 채팅 금지어 관리 모델
+
+**현재 상황:** 금지어를 admin에서 추가/삭제할 방법 없음  
+**프론트 준비:** 관리자 대시보드 채팅 모니터링 섹션에 공간 확보됨
+
+**백엔드 작업:** `chat/models.py`에 추가 (새 모델)
+
+```python
+class BannedWord(models.Model):
+    word = models.CharField(max_length=100, unique=True, help_text="금지 단어/문구")
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'banned_words'
+        ordering = ['word']
+        verbose_name = "금지어"
+        verbose_name_plural = "금지어 관리"
+
+    def __str__(self):
+        return self.word
+```
+
+---
+
+### [우선순위 4] 공지 배너 & 이벤트 모델
+
+**현재 상황:** 사이트 상단 공지 배너가 하드코딩, admin에서 수정 불가  
+**프론트 준비:** admin 대시보드에 placeholder 카드 존재
+
+**백엔드 작업:** `chat/models.py`에 추가
+
+```python
+class SiteBanner(models.Model):
+    message = models.CharField(max_length=300, help_text="배너에 표시할 문구")
+    link_url = models.URLField(blank=True, help_text="클릭 시 이동 URL (선택)")
+    is_active = models.BooleanField(default=False, help_text="현재 배너 ON/OFF")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'site_banners'
+        verbose_name = "사이트 배너"
+        verbose_name_plural = "사이트 배너 관리"
+
+    def __str__(self):
+        return f"{'[ON]' if self.is_active else '[OFF]'} {self.message[:50]}"
+
+
+class SiteEvent(models.Model):
+    title = models.CharField(max_length=200)
+    description = models.TextField(blank=True)
+    starts_at = models.DateTimeField()
+    ends_at = models.DateTimeField(null=True, blank=True)
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'site_events'
+        ordering = ['-starts_at']
+        verbose_name = "이벤트"
+        verbose_name_plural = "이벤트 관리"
+
+    def __str__(self):
+        return self.title
+```
+
+---
+
+### [우선순위 5] AI API 사용량 추적 모델
+
+**현재 상황:** LLM / 이미지 / TTS API 비용 admin에서 볼 수 없음  
+**프론트 준비:** admin 대시보드 AI & 하리 섹션에 placeholder 존재
+
+**백엔드 작업:** `chat/models.py`에 추가
+
+```python
+class ApiUsageLog(models.Model):
+    API_TYPE_CHOICES = [
+        ('llm', 'LLM (텍스트 생성)'),
+        ('image', '이미지 생성'),
+        ('tts', 'TTS (음성 합성)'),
+        ('embedding', '임베딩'),
+    ]
+    api_type = models.CharField(max_length=20, choices=API_TYPE_CHOICES)
+    tokens_used = models.IntegerField(default=0, help_text="사용 토큰 수")
+    cost_usd = models.DecimalField(max_digits=10, decimal_places=6, default=0, help_text="추정 비용 (USD)")
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL,
+        null=True, blank=True
+    )
+    session_id = models.CharField(max_length=255, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'api_usage_logs'
+        ordering = ['-created_at']
+        verbose_name = "API 사용 로그"
+        verbose_name_plural = "AI API 사용량"
+
+    def __str__(self):
+        return f"[{self.api_type}] {self.tokens_used}tok / ${self.cost_usd}"
+```
+
+---
+
+### [우선순위 6] 관리자 접근 로그
+
+**현재 상황:** 관리자가 채팅 로그 등 민감한 데이터에 접근해도 기록 없음
+
+**백엔드 작업:** `chat/models.py`에 추가
+
+```python
+class AdminAccessLog(models.Model):
+    admin_user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE,
+        related_name='admin_access_logs'
+    )
+    path = models.CharField(max_length=500, help_text="접근한 admin URL")
+    action = models.CharField(max_length=100, blank=True, help_text="수행한 액션 설명")
+    accessed_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'admin_access_logs'
+        ordering = ['-accessed_at']
+        verbose_name = "관리자 접근 로그"
+
+    def __str__(self):
+        return f"{self.admin_user.username} → {self.path}"
+```
+
+**미들웨어 추가 요청:**
+```python
+# chat/middleware.py 또는 새 파일
+class AdminAccessLogMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if request.path.startswith('/admin/') and request.user.is_authenticated and request.user.is_staff:
+            from chat.models import AdminAccessLog
+            AdminAccessLog.objects.create(
+                admin_user=request.user,
+                path=request.path,
+            )
+        return response
+```
+
+---
+
+### 요약 체크리스트 (백엔드)
+
+| 기능 | 모델/작업 | 파일 | 우선순위 |
+|---|---|---|---|
+| 대시보드 KPI | `HariAdminSite` 클래스 + `index()` 오버라이드 | `config/urls.py` 또는 신규 파일 | 🔴 높음 |
+| 시나리오 버전 히스토리 | `LorebookVersion` 모델 + `save_model()` 오버라이드 | `rpg/models.py`, `rpg/admin.py` | 🔴 높음 |
+| 채팅 금지어 | `BannedWord` 모델 | `chat/models.py` | 🟡 중간 |
+| 공지 배너 | `SiteBanner` 모델 | `chat/models.py` | 🟡 중간 |
+| 이벤트 관리 | `SiteEvent` 모델 | `chat/models.py` | 🟡 중간 |
+| AI API 사용량 | `ApiUsageLog` 모델 | `chat/models.py` | 🟢 낮음 |
+| 관리자 접근 로그 | `AdminAccessLog` 모델 + middleware | `chat/models.py`, middleware | 🟢 낮음 |
+
+모든 모델 추가 후 `makemigrations` + `migrate` 실행 필요.  
+프론트는 admin.py에 모델 등록만 하면 즉시 admin에 반영됩니다.

--- a/backend/templates/admin/auth/user/change_list.html
+++ b/backend/templates/admin/auth/user/change_list.html
@@ -1,0 +1,150 @@
+{% extends "admin/change_list.html" %}
+{% load static %}
+
+{% block extra_header %}
+<style>
+  .user-mgmt-header {
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    border-radius: 10px;
+    padding: 18px 22px;
+    margin-bottom: 20px;
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+  }
+  .user-mgmt-info h2 {
+    font-size: 0.86rem;
+    font-weight: 700;
+    color: #2a1018;
+    margin: 0 0 5px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .user-mgmt-info h2 svg {
+    width: 15px; height: 15px;
+    stroke: #e05060; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .user-mgmt-info p {
+    font-size: 0.74rem;
+    color: #9a7080;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* 컬럼 가이드 */
+  .user-col-guide {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    flex: 1;
+    min-width: 260px;
+  }
+  .col-chip {
+    background: #fdf8f9;
+    border: 1px solid #f0e0e3;
+    border-radius: 6px;
+    padding: 7px 11px;
+  }
+  .col-chip .col-name {
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: #c04060;
+    display: block;
+    margin-bottom: 2px;
+  }
+  .col-chip .col-desc {
+    font-size: 0.71rem;
+    color: #8a6070;
+    line-height: 1.3;
+  }
+
+  /* 빠른 액션 */
+  .user-quick-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+  .user-quick-actions a {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 14px;
+    border-radius: 6px;
+    font-size: 0.74rem;
+    font-weight: 500;
+    text-decoration: none !important;
+    white-space: nowrap;
+    transition: opacity 0.13s;
+  }
+  .user-quick-actions a:hover { opacity: 0.85; }
+  .ua-add  { background: #ff7b8a; color: #fff !important; }
+  .ua-note { background: #fffbeb; color: #92400e !important; border: 1px solid #fde68a; font-size: 0.69rem; }
+
+  /* 멤버십 뱃지 컬럼 (백엔드 연동 전 스타일만 준비) */
+  .badge-free   { background: #f1f5f9; color: #64748b; }
+  .badge-fan    { background: #fff0f1; color: #e05060; }
+  .badge-fanp   { background: #eff6ff; color: #2563eb; }
+  .badge-bori   { background: #fffbeb; color: #d97706; }
+  .membership-badge {
+    display: inline-flex;
+    padding: 2px 8px;
+    border-radius: 20px;
+    font-size: 0.68rem;
+    font-weight: 600;
+  }
+</style>
+
+<div class="user-mgmt-header">
+  <div class="user-mgmt-info">
+    <h2>
+      <svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+      사용자 관리
+    </h2>
+    <p>
+      전체 가입 유저 목록입니다. is_staff / is_superuser 체크 시 관리자 권한이 부여됩니다.<br>
+      <span style="color:#e05060; font-weight:600;">주의:</span> is_active를 해제하면 해당 유저의 로그인이 즉시 차단됩니다.
+    </p>
+  </div>
+
+  <div class="user-col-guide">
+    <div class="col-chip">
+      <span class="col-name">username</span>
+      <span class="col-desc">로그인 ID (소셜 로그인은<br>자동 생성)</span>
+    </div>
+    <div class="col-chip">
+      <span class="col-name">is_staff</span>
+      <span class="col-desc">ON → /admin/ 접근 가능</span>
+    </div>
+    <div class="col-chip">
+      <span class="col-name">is_active</span>
+      <span class="col-desc">OFF → 로그인 즉시 차단</span>
+    </div>
+    <div class="col-chip">
+      <span class="col-name">date_joined</span>
+      <span class="col-desc">가입 일시 (UTC+9)</span>
+    </div>
+    <div class="col-chip" style="border-style:dashed; opacity:0.6;">
+      <span class="col-name">membership</span>
+      <span class="col-desc">백엔드 모델 연동 후 표시<br>(BACKEND_REQUEST.md)</span>
+    </div>
+  </div>
+
+  <div class="user-quick-actions">
+    <a href="add/" class="ua-add">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      새 유저 추가
+    </a>
+    <span class="ua-note">
+      소셜 로그인 유저는 Google·Naver에서 자동 생성됨
+    </span>
+  </div>
+</div>
+{% endblock %}

--- a/backend/templates/admin/base_site.html
+++ b/backend/templates/admin/base_site.html
@@ -3,102 +3,54 @@
 
 {% block title %}HARI Admin — {{ block.super }}{% endblock %}
 
-{% block extrastyle %}
-  {{ block.super }}
-  <style>
-    /* ── 테마 고정 (다크/라이트 모드 비활성화) ── */
-    :root { color-scheme: light !important; }
-
-    /* ── CSS 변수 (Django base.css 바로 뒤 로드) ── */
-    :root {
-      --primary:               #ff7b8a;
-      --secondary:             #ff5566;
-      --accent:                #ff7b8a;
-      --primary-fg:            #ffffff;
-      --header-color:          #ffffff;
-      --header-branding-color: #ffffff;
-      --header-bg:             #1a1018;
-      --header-link-color:     #ffffff;
-      --breadcrumbs-link-fg:   #ff7b8a;
-      --link-fg:               #ff7b8a;
-      --link-hover-color:      #ff5566;
-      --link-selected-fg:      #ff5566;
-      --button-fg:             #ffffff;
-      --button-bg:             #ff7b8a;
-      --button-hover-bg:       #ff5566;
-      --selected-bg:           #fff0f1;
-      --selected-row:          #fff0f1;
-      --darkened-bg:           #fdf4f4;
-      --body-bg:               #fdf8f8;
-    }
-
-    /* ── 직접 규칙 (변수가 안 먹힐 경우 백업) ── */
-    #header                                { background: #1a1018 !important; }
-    #header a:link, #header a:visited      { color: #ffffff !important; }
-    #user-tools a:link, #user-tools a:visited { color: rgba(255,255,255,0.7) !important; }
-    #user-tools a:hover                    { color: #ffffff !important; }
-
-    a:link, a:visited                      { color: #ff7b8a !important; }
-    a:hover, a:active                      { color: #ff5566 !important; }
-
-    .button, input[type="submit"],
-    input[type="button"], a.button         { background: #ff7b8a !important; border-color: #ff7b8a !important; }
-    .button:hover, input[type="submit"]:hover,
-    input[type="button"]:hover             { background: #ff5566 !important; }
-    .button.default, input[type="submit"].default { background: #1a1018 !important; }
-
-    div.breadcrumbs                        { background: #ff7b8a !important; }
-    div.breadcrumbs a:link,
-    div.breadcrumbs a:visited              { color: rgba(255,255,255,0.85) !important; }
-
-    #changelist-filter h2                  { background: #ff7b8a !important; }
-    #changelist-filter li.selected a       { color: #ff7b8a !important; }
-
-    .module h2, .module caption            { background: #fff0f1 !important; color: #cc4455 !important; }
-
-    tr.selected td                         { background: #fff0f1 !important; }
-    .object-tools a:hover                  { background: #ff5566 !important; }
-  </style>
-{% endblock %}
-
 {% block extrahead %}
   {{ block.super }}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
-    /* ── Django admin CSS 변수 전체 덮어쓰기 ── */
+    /* ── 다크/라이트 모드 강제 비활성화 ── */
+    :root { color-scheme: light !important; }
+
+    /* ══════════════════════════════════════════
+       CSS 변수
+    ══════════════════════════════════════════ */
     :root {
+      /* 사이드바 */
+      --sb-bg:          #0f172a;
+      --sb-hover:       rgba(255,255,255,0.05);
+      --sb-active-bg:   rgba(245,158,11,0.13);
+      --sb-text:        rgba(248,250,252,0.5);
+      --sb-text-active: #f8fafc;
+      --sb-accent:      #f59e0b;
+      --sb-label:       rgba(248,250,252,0.2);
+      --sb-border:      rgba(255,255,255,0.07);
+      --sb-width:       240px;
+
+      /* Django admin 핑크 테마 */
       --primary:                  #ff7b8a;
       --secondary:                #ff5566;
       --accent:                   #ff7b8a;
       --primary-fg:               #ffffff;
-
       --body-fg:                  #2a2420;
-      --body-bg:                  #fdf8f8;
+      --body-bg:                  #f8f5f5;
       --body-quiet-color:         #7a6b68;
       --body-loud-color:          #2a2420;
-
       --header-color:             #ffffff;
       --header-branding-color:    #ffffff;
       --header-bg:                #1a1018;
       --header-link-color:        #ffffff;
-
       --breadcrumbs-fg:           #7a6b68;
-      --breadcrumbs-link-fg:      #ff7b8a;
-      --breadcrumbs-bg:           #ffffff;
-
-      --link-fg:                  #ff7b8a;
-      --link-hover-color:         #ff5566;
+      --breadcrumbs-link-fg:      rgba(255,255,255,0.85);
+      --breadcrumbs-bg:           #ff7b8a;
+      --link-fg:                  #e05060;
+      --link-hover-color:         #c03040;
       --link-selected-fg:         #ff5566;
-
       --hairline-color:           #f0e8e8;
       --border-color:             #f0e8e8;
-
       --darkened-bg:              #fdf4f4;
       --selected-bg:              #fff0f1;
       --selected-row:             #fff0f1;
-
       --button-fg:                #ffffff;
       --button-bg:                #ff7b8a;
       --button-hover-bg:          #ff5566;
@@ -108,52 +60,275 @@
       --close-button-hover-bg:    #7a6b68;
       --delete-button-bg:         #ef4444;
       --delete-button-hover-bg:   #dc2626;
-
       --object-tools-fg:          #ffffff;
       --object-tools-bg:          #9e8f8c;
       --object-tools-hover-bg:    #7a6b68;
-
-      /* 내부 추가 변수 */
       --radius:                   6px;
     }
 
-    /* ── 기본 ── */
+    /* ══════════════════════════════════════════
+       기본 & 폰트
+    ══════════════════════════════════════════ */
     body {
       font-family: 'Inter', system-ui, -apple-system, sans-serif !important;
       font-size: 0.875rem !important;
       -webkit-font-smoothing: antialiased;
+      background: var(--body-bg) !important;
     }
 
-    /* ── 헤더 ── */
+    /* ══════════════════════════════════════════
+       레이아웃: 사이드바 공간 확보
+    ══════════════════════════════════════════ */
     #header {
-      height: 56px !important;
-      line-height: 56px !important;
+      margin-left: var(--sb-width) !important;
+      height: 54px !important;
+      line-height: 54px !important;
       padding: 0 24px !important;
       display: flex !important;
       align-items: center !important;
+      background: #1a1018 !important;
     }
-
     #branding { flex: 1; }
-
     #site-name {
-      font-size: 0.875rem !important;
+      font-size: 0.82rem !important;
       font-weight: 700 !important;
       letter-spacing: 0.02em !important;
       line-height: 1 !important;
     }
-
     #user-tools {
       font-size: 0.75rem !important;
       line-height: 1 !important;
     }
 
-    /* ── 브레드크럼 ── */
+    /* Django 기본 nav-sidebar 제거 */
+    #nav-sidebar,
+    #toggle-nav-sidebar { display: none !important; }
+
+    /* main + content 영역 오프셋 */
+    #main {
+      margin-left: var(--sb-width) !important;
+    }
+    #content.colMS,
+    #content { margin-left: 0 !important; }
+
+    /* breadcrumbs */
     div.breadcrumbs {
+      background: #ff7b8a !important;
       padding: 10px 24px !important;
       font-size: 0.78rem !important;
     }
+    div.breadcrumbs a:link,
+    div.breadcrumbs a:visited { color: rgba(255,255,255,0.85) !important; }
+    div.breadcrumbs a:hover   { color: #ffffff !important; text-decoration: underline !important; }
 
-    /* ── 모듈 (본문 영역) ── */
+    /* content 패딩 */
+    #content { padding: 28px 30px 40px !important; }
+
+    /* ══════════════════════════════════════════
+       커스텀 사이드바
+    ══════════════════════════════════════════ */
+    #hari-sidebar {
+      position: fixed;
+      left: 0; top: 0; bottom: 0;
+      width: var(--sb-width);
+      background: var(--sb-bg);
+      display: flex;
+      flex-direction: column;
+      z-index: 1000;
+      overflow-y: auto;
+      overflow-x: hidden;
+    }
+    #hari-sidebar::-webkit-scrollbar { width: 3px; }
+    #hari-sidebar::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 2px; }
+
+    /* 로고 */
+    .sb-logo {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 17px 16px 15px;
+      border-bottom: 1px solid var(--sb-border);
+      flex-shrink: 0;
+      text-decoration: none !important;
+    }
+    .sb-logo img {
+      height: 26px;
+      width: auto;
+      filter: brightness(0) invert(1);
+      flex-shrink: 0;
+    }
+    .sb-logo-text {
+      font-size: 0.82rem;
+      font-weight: 700;
+      color: #f8fafc;
+      line-height: 1.2;
+    }
+    .sb-logo-sub {
+      font-size: 0.58rem;
+      color: rgba(248,250,252,0.3);
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
+      margin-top: 2px;
+    }
+
+    /* 섹션 그룹 */
+    .sb-section { padding: 14px 8px 2px; }
+
+    .sb-section-label {
+      display: block;
+      font-size: 0.58rem;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--sb-label);
+      padding: 0 8px;
+      margin-bottom: 3px;
+    }
+
+    /* 네비 링크 */
+    .sb-nav { list-style: none; }
+    .sb-nav li { margin-bottom: 1px; }
+
+    .sb-nav a {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      padding: 7px 10px;
+      border-radius: 6px;
+      color: var(--sb-text) !important;
+      text-decoration: none !important;
+      font-size: 0.79rem;
+      font-weight: 500;
+      transition: background 0.14s, color 0.14s;
+      cursor: pointer;
+    }
+    .sb-nav a:hover {
+      background: var(--sb-hover);
+      color: var(--sb-text-active) !important;
+    }
+    .sb-nav a.sb-active {
+      background: var(--sb-active-bg);
+      color: var(--sb-accent) !important;
+    }
+    .sb-nav a.sb-active .sb-icon { opacity: 1; }
+
+    /* 아이콘 */
+    .sb-icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 16px; height: 16px;
+      flex-shrink: 0;
+      opacity: 0.65;
+    }
+    .sb-icon svg {
+      width: 14px; height: 14px;
+      stroke: currentColor;
+      fill: none;
+      stroke-width: 1.8;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    /* disabled (모델 미구현) */
+    .sb-nav a.sb-disabled {
+      opacity: 0.28;
+      cursor: not-allowed;
+      pointer-events: none;
+    }
+
+    /* 뱃지 */
+    .sb-badge {
+      margin-left: auto;
+      font-size: 0.55rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      background: rgba(245,158,11,0.18);
+      color: #f59e0b;
+      padding: 2px 6px;
+      border-radius: 20px;
+      flex-shrink: 0;
+    }
+
+    /* 구분선 */
+    .sb-divider {
+      height: 1px;
+      background: var(--sb-border);
+      margin: 8px 16px;
+    }
+
+    /* 푸터 */
+    .sb-footer {
+      margin-top: auto;
+      padding: 10px 8px 14px;
+      border-top: 1px solid var(--sb-border);
+    }
+    .sb-footer a {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 10px;
+      border-radius: 6px;
+      color: rgba(248,250,252,0.28) !important;
+      text-decoration: none !important;
+      font-size: 0.76rem;
+      font-weight: 500;
+      transition: color 0.14s, background 0.14s;
+    }
+    .sb-footer a:hover {
+      color: rgba(248,250,252,0.65) !important;
+      background: var(--sb-hover);
+    }
+    .sb-footer .sb-icon { opacity: 0.5; }
+
+    /* ══════════════════════════════════════════
+       Django admin 요소 공통 스타일
+    ══════════════════════════════════════════ */
+    a:link, a:visited { color: #e05060 !important; }
+    a:hover, a:active { color: #c03040 !important; }
+
+    /* header 링크는 흰색 */
+    #header a:link, #header a:visited,
+    #user-tools a:link, #user-tools a:visited { color: rgba(255,255,255,0.75) !important; }
+    #user-tools a:hover { color: #ffffff !important; }
+
+    /* 버튼 */
+    .button, input[type="submit"], input[type="button"], a.button {
+      background: #ff7b8a !important;
+      border-color: #ff7b8a !important;
+      border-radius: var(--radius) !important;
+      font-family: inherit !important;
+      font-size: 0.8rem !important;
+      font-weight: 500 !important;
+      box-shadow: none !important;
+    }
+    .button:hover, input[type="submit"]:hover, input[type="button"]:hover {
+      background: #ff5566 !important;
+    }
+    .button.default, input[type="submit"].default,
+    input[type="submit"][name="_continue"],
+    input[type="submit"][name="_addanother"] {
+      background: #2a1f1f !important;
+      border-color: #2a1f1f !important;
+    }
+
+    /* 필터 */
+    #changelist-filter h2 { background: #ff7b8a !important; color: #fff !important; }
+    #changelist-filter li.selected a { color: #ff5566 !important; }
+
+    /* 모듈 헤더 */
+    .module h2, .module caption {
+      background: #fff0f1 !important;
+      color: #cc4455 !important;
+      font-size: 0.65rem !important;
+      font-weight: 600 !important;
+      text-transform: uppercase !important;
+      letter-spacing: 0.07em !important;
+      padding: 10px 16px !important;
+    }
+
+    /* 모듈 */
     .module {
       border: 1px solid var(--border-color) !important;
       border-radius: var(--radius) !important;
@@ -161,124 +336,32 @@
       overflow: hidden;
       margin-bottom: 20px !important;
     }
-
-    .module h2,
-    .module caption {
-      font-size: 0.65rem !important;
-      font-weight: 600 !important;
-      text-transform: uppercase !important;
-      letter-spacing: 0.07em !important;
-      padding: 10px 16px !important;
-    }
-
-    .module table td,
-    .module table th {
-      padding: 10px 16px !important;
-    }
-
-    /* ── 사이드바 ── */
     #nav-sidebar .module {
-      border: none !important;
-      border-radius: 0 !important;
-      box-shadow: none !important;
-      margin-bottom: 0 !important;
+      border: none !important; border-radius: 0 !important;
+      box-shadow: none !important; margin-bottom: 0 !important;
     }
 
-    #nav-sidebar .module caption {
-      font-size: 0.6rem !important;
-      font-weight: 700 !important;
-      letter-spacing: 0.1em !important;
-      padding: 8px 12px !important;
-      text-transform: uppercase !important;
+    tr.selected td { background: #fff0f1 !important; }
+    .object-tools a:hover { background: #ff5566 !important; }
+
+    /* 인풋 포커스 */
+    input[type="text"]:focus, input[type="password"]:focus,
+    input[type="email"]:focus, textarea:focus, select:focus {
+      border-color: #ff7b8a !important;
+      box-shadow: 0 0 0 3px rgba(255,123,138,0.15) !important;
+      outline: none !important;
     }
 
-    #nav-sidebar .module table th a:link,
-    #nav-sidebar .module table th a:visited,
-    #nav-sidebar .module table th a {
-      font-size: 0.8rem !important;
-      font-weight: 600 !important;
-      color: #2a1018 !important;
-    }
-
-    #nav-sidebar .module table th a:hover {
-      color: #ff5566 !important;
-      text-decoration: none !important;
-    }
-
-    #nav-sidebar .module table td a:link,
-    #nav-sidebar .module table td a:visited,
-    #nav-sidebar .module table td a {
-      color: #7a5060 !important;
-      font-size: 0.77rem !important;
-    }
-
-    #nav-sidebar .module table td a:hover {
-      color: #ff5566 !important;
-      text-decoration: none !important;
-    }
-
-    #nav-sidebar .module table td,
-    #nav-sidebar .module table th {
-      border-bottom: 1px solid #f5dde0 !important;
-      padding: 7px 12px !important;
-    }
-
-    #nav-sidebar .module tbody tr:hover {
-      background: #fff0f2 !important;
-    }
-
-    /* ── 버튼 ── */
-    .button,
-    input[type="submit"],
-    input[type="button"],
-    .submit-row input,
-    a.button {
-      border-radius: var(--radius) !important;
-      font-family: inherit !important;
-      font-size: 0.8rem !important;
-      font-weight: 500 !important;
-      box-shadow: none !important;
-      transform: none !important;
-    }
-
-    .button:hover,
-    input[type="submit"]:hover,
-    input[type="button"]:hover {
-      box-shadow: none !important;
-      transform: none !important;
-    }
-
-    /* ── 폼 인풋 ── */
-    input[type="text"],
-    input[type="password"],
-    input[type="email"],
-    input[type="url"],
-    input[type="number"],
-    textarea,
-    select {
-      border-radius: var(--radius) !important;
-      font-family: inherit !important;
-      font-size: 0.82rem !important;
-    }
-
-    input[type="text"]:focus,
-    input[type="password"]:focus,
-    input[type="email"]:focus,
-    textarea:focus,
-    select:focus {
-      box-shadow: 0 0 0 3px rgba(59,130,246,0.15) !important;
-    }
-
-    /* ── 체인지리스트 헤더 ── */
+    /* 테이블 */
     #changelist table thead th {
       font-size: 0.65rem !important;
       font-weight: 600 !important;
       text-transform: uppercase !important;
       letter-spacing: 0.07em !important;
-      padding: 10px 16px !important;
     }
+    #changelist tbody tr:hover { background: rgba(255,123,138,0.04) !important; }
 
-    /* ── 메시지 ── */
+    /* 메시지 */
     .messagelist li {
       border-radius: var(--radius) !important;
       font-size: 0.82rem !important;
@@ -286,25 +369,338 @@
       margin-bottom: 8px !important;
     }
 
-    /* ── 서밋 로우 ── */
-    .submit-row {
-      padding: 14px 16px !important;
+    /* 기타 */
+    #theme-toggle, .theme-toggle { display: none !important; }
+    ::-webkit-scrollbar { width: 5px; height: 5px; }
+    ::-webkit-scrollbar-thumb { background: #e0d0d3; border-radius: 3px; }
+
+    /* ══════════════════════════════════════════
+       모바일 반응형
+    ══════════════════════════════════════════ */
+
+    /* 모바일 햄버거 버튼 */
+    #sb-toggle-btn {
+      display: none;
+      position: fixed;
+      top: 12px;
+      left: 12px;
+      z-index: 1100;
+      width: 36px; height: 36px;
+      background: #1e293b;
+      border: 1px solid rgba(255,255,255,0.12);
+      border-radius: 8px;
+      cursor: pointer;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      gap: 4px;
+      padding: 0;
+    }
+    #sb-toggle-btn span {
+      display: block;
+      width: 16px; height: 2px;
+      background: rgba(248,250,252,0.7);
+      border-radius: 1px;
+      transition: transform 0.2s, opacity 0.2s;
+    }
+    #sb-toggle-btn.open span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+    #sb-toggle-btn.open span:nth-child(2) { opacity: 0; }
+    #sb-toggle-btn.open span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+
+    /* 오버레이 */
+    #sb-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.5);
+      z-index: 999;
+      backdrop-filter: blur(2px);
     }
 
-    /* ── 테마 전환 버튼 숨김 (다크/라이트 모드 불필요) ── */
-    #theme-toggle { display: none !important; }
-    .theme-toggle { display: none !important; }
+    @media (max-width: 900px) {
+      #sb-toggle-btn { display: flex; }
 
-    /* ── 스크롤바 ── */
-    ::-webkit-scrollbar { width: 4px; height: 4px; }
-    ::-webkit-scrollbar-thumb { background: var(--border-color); border-radius: 2px; }
+      #hari-sidebar {
+        transform: translateX(calc(-1 * var(--sb-width)));
+        transition: transform 0.22s ease;
+        z-index: 1000;
+      }
+      #hari-sidebar.sb-open { transform: translateX(0); }
+
+      #header {
+        margin-left: 0 !important;
+        padding-left: 52px !important;
+      }
+      #main { margin-left: 0 !important; }
+
+      #content { padding: 18px 16px 32px !important; }
+    }
+
+    @media (max-width: 600px) {
+      /* 테이블 가로 스크롤 */
+      #changelist { overflow-x: auto; }
+      #result_list { min-width: 560px; }
+
+      /* 대시보드 그리드 */
+      .model-grid,
+      .recent-wrap { grid-template-columns: 1fr !important; }
+
+      .dash-banner { flex-direction: column; }
+    }
   </style>
 {% endblock %}
 
+{% block nav-global %}
+<!-- 모바일 오버레이 -->
+<div id="sb-overlay"></div>
+<!-- 햄버거 버튼 -->
+<button id="sb-toggle-btn" aria-label="메뉴 열기/닫기">
+  <span></span><span></span><span></span>
+</button>
+
+<aside id="hari-sidebar">
+
+  <!-- 로고 -->
+  <a class="sb-logo" href="/admin/">
+    <img src="{% static 'images/hari_logo_none.png' %}" alt="HARI">
+    <div>
+      <div class="sb-logo-text">HARI Admin</div>
+      <div class="sb-logo-sub">chatting-hari.com</div>
+    </div>
+  </a>
+
+  <!-- ① 핵심 -->
+  <div class="sb-section">
+    <span class="sb-section-label">핵심</span>
+    <ul class="sb-nav">
+      <li>
+        <a href="/admin/" data-match="^/admin/$">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+          </span>
+          대시보드
+        </a>
+      </li>
+      <li>
+        <a href="/admin/auth/user/" data-match="^/admin/auth/user/">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+          </span>
+          사용자 관리
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <!-- ② 롤플레잉 관리 -->
+  <div class="sb-section">
+    <span class="sb-section-label">롤플레잉 관리</span>
+    <ul class="sb-nav">
+      <li>
+        <a href="/admin/rpg/lorebook/" data-match="^/admin/rpg/lorebook/">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/><line x1="12" y1="6" x2="16" y2="6"/><line x1="12" y1="10" x2="16" y2="10"/></svg>
+          </span>
+          시나리오 (로어북)
+          <span class="sb-badge">핵심</span>
+        </a>
+      </li>
+      <li>
+        <a href="/admin/rpg/session/" data-match="^/admin/rpg/session/">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+          </span>
+          RPG 세션
+        </a>
+      </li>
+      <li>
+        <a href="/admin/rpg/hypermemory/" data-match="^/admin/rpg/hypermemory/">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
+          </span>
+          하이퍼 메모리
+        </a>
+      </li>
+      <li>
+        <a href="/admin/rpg/characterimage/" data-match="^/admin/rpg/characterimage/">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg>
+          </span>
+          캐릭터 이미지
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <!-- ③ AI & 하리 설정 -->
+  <div class="sb-section">
+    <span class="sb-section-label">AI & 하리 설정</span>
+    <ul class="sb-nav">
+      <li>
+        <a href="/admin/chat/hariknowledge/" data-match="^/admin/chat/hariknowledge/">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+          </span>
+          하리 지식
+          <span class="sb-badge">핵심</span>
+        </a>
+      </li>
+      <li>
+        <a href="/admin/chat/userpersona/" data-match="^/admin/chat/userpersona/">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+          </span>
+          유저 페르소나
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <!-- ④ 채팅 모니터링 -->
+  <div class="sb-section">
+    <span class="sb-section-label">채팅 모니터링</span>
+    <ul class="sb-nav">
+      <li>
+        <a href="/admin/chat/message/" data-match="^/admin/chat/message/">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><line x1="9" y1="10" x2="15" y2="10"/><line x1="9" y1="14" x2="13" y2="14"/></svg>
+          </span>
+          채팅 메시지
+        </a>
+      </li>
+      <li>
+        <a href="/admin/chat/chatmemory/" data-match="^/admin/chat/chatmemory/">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg>
+          </span>
+          채팅 메모리
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <!-- ⑤ 콘텐츠 관리 -->
+  <div class="sb-section">
+    <span class="sb-section-label">콘텐츠 관리</span>
+    <ul class="sb-nav">
+      <li>
+        <a href="/admin/chat/generatedcontent/" data-match="^/admin/chat/generatedcontent/">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><line x1="10" y1="9" x2="8" y2="9"/></svg>
+          </span>
+          생성 콘텐츠
+        </a>
+      </li>
+      <li>
+        <a href="/admin/chat/visitlog/" data-match="^/admin/chat/visitlog/">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+          </span>
+          방문 로그
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="sb-divider"></div>
+
+  <!-- ⑥ 예정 (백엔드 협의) -->
+  <div class="sb-section">
+    <span class="sb-section-label">예정 — 백엔드 협의 필요</span>
+    <ul class="sb-nav">
+      <li>
+        <a href="#" class="sb-disabled">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
+          </span>
+          멤버십 &amp; 결제
+        </a>
+      </li>
+      <li>
+        <a href="#" class="sb-disabled">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><path d="M18 8h1a4 4 0 0 1 0 8h-1"/><path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z"/><line x1="6" y1="1" x2="6" y2="4"/><line x1="10" y1="1" x2="10" y2="4"/><line x1="14" y1="1" x2="14" y2="4"/></svg>
+          </span>
+          공지 &amp; 이벤트
+        </a>
+      </li>
+      <li>
+        <a href="#" class="sb-disabled">
+          <span class="sb-icon">
+            <svg viewBox="0 0 24 24"><path d="M9 3H5a2 2 0 0 0-2 2v4m6-6h10a2 2 0 0 1 2 2v4M9 3v18m0 0h10a2 2 0 0 0 2-2V9M9 21H5a2 2 0 0 1-2-2V9m0 0h18"/></svg>
+          </span>
+          시스템 &amp; 로그
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <!-- 푸터 -->
+  <div class="sb-footer">
+    <a href="/">
+      <span class="sb-icon">
+        <svg viewBox="0 0 24 24"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+      </span>
+      사이트로 돌아가기
+    </a>
+    <a href="{% url 'admin:logout' %}">
+      <span class="sb-icon">
+        <svg viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+      </span>
+      로그아웃
+    </a>
+  </div>
+</aside>
+
+<script>
+(function () {
+  // ── Active 상태 감지 ──
+  var path = window.location.pathname;
+  document.querySelectorAll('#hari-sidebar .sb-nav a[data-match]').forEach(function (a) {
+    if (new RegExp(a.getAttribute('data-match')).test(path)) {
+      a.classList.add('sb-active');
+    }
+  });
+
+  // ── 모바일 햄버거 토글 ──
+  var btn     = document.getElementById('sb-toggle-btn');
+  var sidebar = document.getElementById('hari-sidebar');
+  var overlay = document.getElementById('sb-overlay');
+
+  function openSidebar() {
+    sidebar.classList.add('sb-open');
+    btn.classList.add('open');
+    overlay.style.display = 'block';
+    document.body.style.overflow = 'hidden';
+  }
+  function closeSidebar() {
+    sidebar.classList.remove('sb-open');
+    btn.classList.remove('open');
+    overlay.style.display = 'none';
+    document.body.style.overflow = '';
+  }
+
+  if (btn) {
+    btn.addEventListener('click', function () {
+      sidebar.classList.contains('sb-open') ? closeSidebar() : openSidebar();
+    });
+  }
+  if (overlay) {
+    overlay.addEventListener('click', closeSidebar);
+  }
+  // 사이드바 링크 클릭 시 모바일에서 닫기
+  sidebar.querySelectorAll('a').forEach(function (a) {
+    a.addEventListener('click', function () {
+      if (window.innerWidth <= 900) closeSidebar();
+    });
+  });
+}());
+</script>
+{% endblock %}
+
 {% block branding %}
-  <h1 id="site-name" style="display:flex; align-items:center; gap:10px;">
-    <a href="{% url 'admin:index' %}" style="display:flex; align-items:center; gap:10px; text-decoration:none; color:inherit;">
-      <img src="{% static 'images/hari_logo_none.png' %}" alt="HARI" style="height:28px; width:auto; filter: brightness(0) invert(1);">
+  <h1 id="site-name">
+    <a href="{% url 'admin:index' %}" style="text-decoration:none !important; color:inherit !important; display:flex; align-items:center; gap:8px;">
       HARI Admin
     </a>
   </h1>

--- a/backend/templates/admin/change_form.html
+++ b/backend/templates/admin/change_form.html
@@ -1,246 +1,454 @@
 {% extends "admin/base_site.html" %}
-{% load admin_urls static admin %}
+{% load admin_urls static admin i18n %}
 
-{% block title %}{{ original|truncatewords:"30" }} | HARI 관리자{% endblock %}
+{% block title %}
+  {% if original %}{{ original|truncatewords:"30" }}{% else %}새 {{ opts.verbose_name }}{% endif %} | HARI 관리자
+{% endblock %}
 
 {% block extrahead %}
   {{ block.super }}
   <style>
-    /* ── 폼 레이아웃 ────────────────────────────────────────── */
-    form {
+    /* ══════════════════════════════════════════
+       폼 레이아웃
+    ══════════════════════════════════════════ */
+    #content-main {
       max-width: 900px;
     }
 
-    .form-row {
-      margin-bottom: 20px;
-      padding-bottom: 20px;
-      border-bottom: 1px solid #eee;
+    /* 페이지 타이틀 */
+    #content-main h1 {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #2a1018;
+      margin: 0 0 22px;
+      padding-bottom: 14px;
+      border-bottom: 1px solid #f0e0e3;
+      display: flex;
+      align-items: center;
+      gap: 8px;
     }
 
-    .form-row:last-child {
+    /* 오브젝트 툴 */
+    .object-tools { margin-bottom: 16px; }
+    .object-tools a {
+      border-radius: var(--radius) !important;
+      font-size: 0.75rem !important;
+      padding: 6px 12px !important;
+    }
+
+    /* ── fieldset ── */
+    fieldset {
+      background: #ffffff;
+      border: 1px solid #f0e0e3;
+      border-radius: 8px;
+      padding: 0;
+      margin-bottom: 18px;
+      overflow: hidden;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+    }
+
+    fieldset h2,
+    fieldset > .description {
+      font-size: 0.65rem !important;
+      font-weight: 700 !important;
+      text-transform: uppercase !important;
+      letter-spacing: 0.08em !important;
+      color: #c04060 !important;
+      background: #fff5f6 !important;
+      padding: 10px 18px !important;
+      margin: 0 !important;
+      border-bottom: 1px solid #f5dde0 !important;
+    }
+
+    fieldset .form-row {
+      padding: 14px 18px;
+      border-bottom: 1px solid #f9eef0;
+    }
+    fieldset .form-row:last-child {
       border-bottom: none;
-      margin-bottom: 0;
-      padding-bottom: 0;
+    }
+    fieldset .form-row.errors {
+      background: #fff5f5;
+      border-left: 3px solid #ef4444;
     }
 
-    /* ── 라벨 및 입력 필드 ────────────────────────────────────────── */
-    label {
+    /* ── 라벨 ── */
+    .form-row label,
+    .form-row > label {
       display: block;
-      color: #2a2420;
+      font-size: 0.78rem;
       font-weight: 600;
-      margin-bottom: 8px;
-      font-size: 14px;
+      color: #3a2028;
+      margin-bottom: 6px;
+    }
+    .form-row label.required::after {
+      content: ' *';
+      color: #ff5566;
     }
 
+    /* ── 인풋 공통 ── */
     input[type="text"],
     input[type="email"],
     input[type="password"],
     input[type="number"],
+    input[type="url"],
     input[type="date"],
     input[type="datetime-local"],
-    textarea,
     select {
       width: 100%;
-      max-width: 500px;
-      padding: 12px 15px;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      font-size: 14px;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-      transition: border-color 0.2s ease;
+      max-width: 520px;
+      padding: 9px 12px;
+      border: 1px solid #e8d8db;
+      border-radius: var(--radius);
+      font-size: 0.82rem;
+      font-family: inherit;
+      color: #2a1018;
+      background: #fff;
+      transition: border-color 0.15s, box-shadow 0.15s;
     }
-
     input[type="text"]:focus,
     input[type="email"]:focus,
     input[type="password"]:focus,
     input[type="number"]:focus,
-    input[type="date"]:focus,
-    input[type="datetime-local"]:focus,
-    textarea:focus,
+    input[type="url"]:focus,
     select:focus {
-      outline: none;
       border-color: #ff7b8a;
-      box-shadow: 0 0 0 3px rgba(255, 123, 138, 0.1);
+      box-shadow: 0 0 0 3px rgba(255,123,138,0.12);
+      outline: none;
     }
 
+    /* ── textarea 기본 ── */
     textarea {
+      width: 100%;
+      max-width: 720px;
+      padding: 10px 13px;
+      border: 1px solid #e8d8db;
+      border-radius: var(--radius);
+      font-size: 0.82rem;
+      font-family: inherit;
+      color: #2a1018;
       resize: vertical;
-      min-height: 150px;
+      min-height: 100px;
+      transition: border-color 0.15s, box-shadow 0.15s;
+      line-height: 1.6;
+    }
+    textarea:focus {
+      border-color: #ff7b8a;
+      box-shadow: 0 0 0 3px rgba(255,123,138,0.12);
+      outline: none;
     }
 
-    /* ── 체크박스 ────────────────────────────────────────── */
-    input[type="checkbox"] {
-      margin-right: 8px;
-      cursor: pointer;
+    /* ══════════════════════════════════════════
+       코드 에디터 스타일 textarea
+       - Lorebook 프롬프트·lorebook 필드 등 긴 텍스트에 적용
+    ══════════════════════════════════════════ */
+    .code-editor-wrap {
+      position: relative;
+      border: 1px solid #cbd5e1;
+      border-radius: 7px;
+      overflow: hidden;
+      background: #0f172a;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.12);
     }
 
+    .code-editor-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 14px;
+      background: #1e293b;
+      border-bottom: 1px solid rgba(255,255,255,0.07);
+    }
+    .code-editor-bar-dots {
+      display: flex;
+      gap: 5px;
+    }
+    .code-editor-bar-dots span {
+      width: 10px; height: 10px;
+      border-radius: 50%;
+    }
+    .dot-red    { background: #ef4444; }
+    .dot-yellow { background: #f59e0b; }
+    .dot-green  { background: #22c55e; }
+    .code-editor-label {
+      font-size: 0.65rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgba(248,250,252,0.35);
+    }
+    .code-editor-hint {
+      font-size: 0.62rem;
+      color: rgba(248,250,252,0.22);
+    }
+
+    .code-editor-wrap textarea {
+      max-width: 100%;
+      width: 100%;
+      min-height: 320px;
+      border: none;
+      border-radius: 0;
+      background: #0f172a;
+      color: #e2e8f0;
+      font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'Consolas', 'Monaco', monospace;
+      font-size: 0.82rem;
+      line-height: 1.7;
+      padding: 14px 18px;
+      resize: vertical;
+      tab-size: 2;
+      caret-color: #f59e0b;
+    }
+    .code-editor-wrap textarea:focus {
+      border: none;
+      box-shadow: none;
+      outline: none;
+      background: #0f1e35;
+    }
+    .code-editor-footer {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      padding: 6px 14px;
+      background: #1e293b;
+      border-top: 1px solid rgba(255,255,255,0.07);
+      gap: 14px;
+    }
+    .code-editor-footer span {
+      font-size: 0.62rem;
+      color: rgba(248,250,252,0.28);
+    }
+    #lorebook-char-count { color: rgba(245,158,11,0.7); }
+
+    /* ── 체크박스 ── */
     .checkbox-row {
       display: flex;
       align-items: center;
-      margin-bottom: 15px;
+      gap: 8px;
     }
-
+    .checkbox-row input[type="checkbox"] {
+      width: 15px; height: 15px;
+      accent-color: #ff7b8a;
+      cursor: pointer;
+    }
     .checkbox-row label {
       margin-bottom: 0;
-      margin-left: 8px;
       font-weight: 400;
-    }
-
-    /* ── 제출 버튼 및 삭제 링크 ────────────────────────────────────────── */
-    .submit-row {
-      background: white;
-      padding: 20px 0;
-      margin-top: 30px;
-      border-top: 2px solid #ff7b8a;
-      display: flex;
-      gap: 10px;
-    }
-
-    .submit-row input[type="submit"],
-    .submit-row input[type="button"] {
-      padding: 12px 30px;
-      font-size: 14px;
-      font-weight: 600;
-      border: none;
-      border-radius: 4px;
       cursor: pointer;
-      transition: all 0.3s ease;
     }
 
-    .submit-row input[type="submit"] {
-      background: #ff7b8a;
-      color: white;
-    }
-
-    .submit-row input[type="submit"]:hover {
-      background: #ff5566;
-      transform: translateY(-2px);
-      box-shadow: 0 4px 12px rgba(255, 123, 138, 0.3);
-    }
-
-    .deletelink {
-      color: #d9534f;
-      text-decoration: none;
-      font-weight: 600;
-    }
-
-    .deletelink:hover {
-      color: #c9302c;
-    }
-
-    /* ── 필드셋 및 에러 메시지 ────────────────────────────────────────── */
-    .fieldset {
-      background: white;
-      border: 1px solid #ddd;
-      border-radius: 6px;
-      padding: 20px;
-      margin-bottom: 20px;
-    }
-
-    .fieldset h2 {
-      color: #2a2420;
-      font-size: 16px;
-      margin-bottom: 20px;
-      padding-bottom: 10px;
-      border-bottom: 2px solid #ff7b8a;
-      font-weight: 600;
-    }
-
-    .help-text {
-      font-size: 12px;
-      color: #999;
+    /* ── help text ── */
+    .help {
+      font-size: 0.72rem;
+      color: #a07080;
       margin-top: 5px;
-      font-style: italic;
+      line-height: 1.4;
     }
 
-    /* ── 에러 리스트 ────────────────────────────────────────── */
+    /* ── 에러 ── */
     .errorlist {
-      background: #fee;
-      border: 1px solid #fcc;
-      border-radius: 4px;
-      padding: 15px;
-      margin-bottom: 20px;
-      color: #c33;
+      background: #fff5f5;
+      border: 1px solid #fed7d7;
+      border-radius: var(--radius);
+      padding: 12px 16px;
+      margin-bottom: 18px;
+      list-style: disc;
+      padding-left: 30px;
     }
-
     .errorlist li {
-      margin-bottom: 8px;
+      color: #c53030;
+      font-size: 0.8rem;
+      margin-bottom: 4px;
     }
+    .errorlist li:last-child { margin-bottom: 0; }
 
-    .errorlist li:last-child {
-      margin-bottom: 0;
-    }
-
-    .form-row.errors {
-      background: #fee;
-      padding: 15px;
-      border-radius: 4px;
-      border-left: 4px solid #c33;
-    }
-
-    .form-row.errors label {
-      color: #c33;
-    }
-
-    /* ── 읽기 전용 필드 ────────────────────────────────────────── */
+    /* ── 읽기 전용 ── */
     .readonly {
-      background: #f5f5f5;
-      padding: 10px 15px;
-      border-radius: 4px;
-      border: 1px solid #ddd;
-      color: #666;
+      display: inline-block;
+      background: #f5f0f0;
+      border: 1px solid #e8d8db;
+      border-radius: var(--radius);
+      padding: 8px 12px;
+      font-size: 0.81rem;
+      color: #6a5060;
+      max-width: 520px;
+    }
+
+    /* ── submit-row ── */
+    .submit-row {
+      background: #fff;
+      border: 1px solid #f0e0e3;
+      border-radius: 8px;
+      padding: 16px 18px;
+      margin-top: 8px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+    .submit-row input[type="submit"] {
+      padding: 9px 24px !important;
+      font-size: 0.82rem !important;
+      font-weight: 600 !important;
+      border-radius: var(--radius) !important;
+      cursor: pointer;
+    }
+    .submit-row .deletelink-box {
+      margin-left: auto;
+    }
+    .deletelink {
+      color: #ef4444 !important;
+      font-size: 0.78rem;
+      font-weight: 500;
+      text-decoration: none !important;
+      padding: 8px 12px;
+      border: 1px solid #fecaca;
+      border-radius: var(--radius);
+      transition: background 0.14s;
+    }
+    .deletelink:hover {
+      background: #fff5f5 !important;
+      color: #dc2626 !important;
     }
   </style>
 {% endblock %}
 
 {% block content_title %}
-  <h1>{{ opts.verbose_name | capfirst }} 수정</h1>
+  <h1>
+    {% if original %}
+      {{ opts.verbose_name|capfirst }} 수정
+    {% else %}
+      새 {{ opts.verbose_name|capfirst }} 추가
+    {% endif %}
+  </h1>
 {% endblock %}
 
-{% block form %}
-  <form method="post" class="form-wrapper">
+{% block content %}
+<div id="content-main">
+  {% if is_popup %}{% block popup_response_template %}{% endblock %}{% endif %}
+
+  {% if save_on_top %}
+    <div class="submit-row">
+      {% submit_row %}
+    </div>
+  {% endif %}
+
+  {% if errors %}
+    <ul class="errorlist">
+      {% for error in errors %}
+        <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+
+  <form id="{{ opts.model_name }}_form"
+        {% if has_file_field %}enctype="multipart/form-data"{% endif %}
+        action="" method="post" novalidate>
     {% csrf_token %}
 
-    {% if form.non_field_errors %}
-      <div class="errorlist">
-        {% for error in form.non_field_errors %}
-          <li>{{ error }}</li>
-        {% endfor %}
-      </div>
+    {% if original %}
+      <input type="hidden" name="_change_pk" value="{{ original.pk }}">
     {% endif %}
 
-    {% for fieldset in adminform %}
-      <fieldset>
-        {% if fieldset.name %}
-          <h2>{{ fieldset.name }}</h2>
-        {% endif %}
-
-        {% for line in fieldset %}
-          {% if line.errors %}
-            <div class="form-row errors">
-              {{ line.errors }}
-          {% else %}
-            <div class="form-row">
+    {% block field_sets %}
+      {% for fieldset in adminform %}
+        <fieldset class="module{% if fieldset.classes %} {{ fieldset.classes }}{% endif %}">
+          {% if fieldset.name %}
+            <h2>{{ fieldset.name }}</h2>
           {% endif %}
-            {% if line.label %}
-              <label for="{{ line.field.id_for_label }}">{{ line.label }}</label>
-            {% endif %}
-            {{ line.field }}
-            {% if line.help_text %}
-              <div class="help-text">{{ line.help_text|safe }}</div>
-            {% endif %}
+          {% if fieldset.description %}
+            <div class="description">{{ fieldset.description|safe }}</div>
+          {% endif %}
+          {% for line in fieldset %}
+            <div class="form-row{% if line.fields|length == 1 and line.errors %} errors{% endif %}{% if line.fields|length == 1 %} field-{{ line.fields.0 }}{% endif %}">
+              {% if line.fields|length == 1 and line.errors %}
+                {{ line.errors }}
+              {% endif %}
+              {% for field in line %}
+                <div class="fieldWrapper{% if field.errors %} errors{% endif %}">
+                  {% if field.is_hidden %}
+                    {{ field.field }}
+                  {% else %}
+                    {{ field.label_tag }}
+                    {% if field.errors %}<ul class="errorlist">{% for e in field.errors %}<li>{{ e }}</li>{% endfor %}</ul>{% endif %}
+
+                    {# ── 코드 에디터 적용 조건: lorebook / lorebook_prompt / system_prompt 필드 #}
+                    {% if field.field.name == "lorebook" or field.field.name == "lorebook_prompt" or field.field.name == "system_prompt" or field.field.name == "trait_value" and field.field.name != "trait_key" %}
+                      <div class="code-editor-wrap" id="editor-wrap-{{ field.html_name }}">
+                        <div class="code-editor-bar">
+                          <div class="code-editor-bar-dots">
+                            <span class="dot-red"></span>
+                            <span class="dot-yellow"></span>
+                            <span class="dot-green"></span>
+                          </div>
+                          <span class="code-editor-label">
+                            {% if field.field.name == "lorebook" %}Lorebook Prompt{% elif field.field.name == "lorebook_prompt" %}Lorebook Prompt{% elif field.field.name == "system_prompt" %}System Prompt{% else %}{{ field.label }}{% endif %}
+                          </span>
+                          <span class="code-editor-hint">Tab = 2 spaces</span>
+                        </div>
+                        {{ field.field }}
+                        <div class="code-editor-footer">
+                          <span id="lorebook-char-count-{{ field.html_name }}">0자</span>
+                          <span>monospace · UTF-8</span>
+                        </div>
+                      </div>
+                      <script>
+                      (function() {
+                        var ta = document.querySelector('#editor-wrap-{{ field.html_name }} textarea');
+                        var counter = document.getElementById('lorebook-char-count-{{ field.html_name }}');
+                        if (!ta || !counter) return;
+                        function update() { counter.textContent = ta.value.length.toLocaleString() + '자'; }
+                        update();
+                        ta.addEventListener('input', update);
+                        /* Tab 키 → 2 spaces */
+                        ta.addEventListener('keydown', function(e) {
+                          if (e.key === 'Tab') {
+                            e.preventDefault();
+                            var s = ta.selectionStart, end = ta.selectionEnd;
+                            ta.value = ta.value.substring(0, s) + '  ' + ta.value.substring(end);
+                            ta.selectionStart = ta.selectionEnd = s + 2;
+                            update();
+                          }
+                        });
+                      }());
+                      </script>
+                    {% else %}
+                      {{ field.field }}
+                    {% endif %}
+
+                    {% if field.field.help_text %}
+                      <div class="help">{{ field.field.help_text|safe }}</div>
+                    {% endif %}
+                  {% endif %}
+                </div>
+              {% endfor %}
             </div>
           {% endfor %}
-      </fieldset>
-    {% endfor %}
+        </fieldset>
+      {% endfor %}
+    {% endblock %}
 
-    <div class="submit-row">
-      <input type="submit" value="💾 저장" />
-      {% if has_delete_permission %}
-        <span class="deletelink">
-          <a href="{% url opts|admin_urlname:'delete' original.pk %}">🗑 삭제</a>
-        </span>
-      {% endif %}
-    </div>
+    {% block after_field_sets %}{% endblock %}
+
+    {% block inline_field_sets %}
+      {% for inline_admin_formset in inline_admin_formsets %}
+        {% include inline_admin_formset.opts.template %}
+      {% endfor %}
+    {% endblock %}
+
+    {% block submit_buttons_bottom %}
+      <div class="submit-row">
+        {% if show_save %}<input type="submit" value="저장" name="_save" class="default">{% endif %}
+        {% if show_save_and_continue %}<input type="submit" value="저장 후 계속 편집" name="_continue">{% endif %}
+        {% if show_save_and_add_another %}<input type="submit" value="저장 후 새 항목 추가" name="_addanother">{% endif %}
+        {% if show_delete_link and original %}
+          <div class="deletelink-box">
+            <a href="{% url opts|admin_urlname:'delete' original.pk %}" class="deletelink">삭제</a>
+          </div>
+        {% endif %}
+      </div>
+    {% endblock %}
+
+    {% block admin_change_form_document_ready %}{% endblock %}
   </form>
+</div>
 {% endblock %}

--- a/backend/templates/admin/change_list.html
+++ b/backend/templates/admin/change_list.html
@@ -1,189 +1,287 @@
 {% extends "admin/base_site.html" %}
-{% load admin_urls static admin %}
+{% load admin_urls static admin i18n %}
 
-{% block title %}{{ cl.opts.verbose_name_plural | capfirst }} | HARI 관리자{% endblock %}
+{% block title %}{{ cl.opts.verbose_name_plural|capfirst }} | HARI 관리자{% endblock %}
 
 {% block extrahead %}
   {{ block.super }}
   <style>
-    /* ── 목록 헤더 ────────────────────────────────────────── */
-    .changelist-header {
+    /* ══════════════════════════════════════════
+       change_list 공통 스타일
+    ══════════════════════════════════════════ */
+
+    /* 오브젝트 툴 (상단 우측 버튼) */
+    .object-tools { margin-bottom: 14px; }
+    .object-tools a {
+      border-radius: var(--radius) !important;
+      font-size: 0.75rem !important;
+      font-weight: 500 !important;
+      padding: 6px 14px !important;
+    }
+    .object-tools a.addlink {
+      background: #ff7b8a !important;
+      padding-left: 28px !important;
+    }
+
+    /* ── 검색 폼 ── */
+    #changelist-search {
+      margin-bottom: 16px;
+    }
+    #changelist-search form {
       display: flex;
-      justify-content: space-between;
       align-items: center;
-      margin-bottom: 25px;
-      flex-wrap: wrap;
-      gap: 15px;
+      gap: 8px;
     }
-
-    .changelist-header h1 {
-      font-size: 24px;
-      color: #2a2420;
-      margin: 0;
-      font-weight: 600;
-    }
-
-    .changelist-filters {
-      float: right;
-      margin-left: 20px;
-      width: 240px;
-    }
-
-    .changelist-filters h2 {
-      color: #2a2420;
-      font-size: 14px;
-      text-transform: uppercase;
-      margin-bottom: 15px;
-      padding-bottom: 10px;
-      border-bottom: 2px solid #ff7b8a;
-      font-weight: 600;
-    }
-
-    .changelist-filters ul {
-      list-style: none;
-      padding: 0;
-    }
-
-    .changelist-filters li {
-      padding: 8px 0;
-    }
-
-    .changelist-filters a {
-      color: #ff7b8a;
-      text-decoration: none;
+    #changelist-search input[type="text"] {
       padding: 8px 12px;
-      border-radius: 4px;
-      display: block;
-      transition: all 0.2s ease;
+      border: 1px solid #e8d8db;
+      border-radius: var(--radius);
+      font-size: 0.82rem;
+      font-family: inherit;
+      min-width: 260px;
+      transition: border-color 0.15s, box-shadow 0.15s;
+    }
+    #changelist-search input[type="text"]:focus {
+      border-color: #ff7b8a;
+      box-shadow: 0 0 0 3px rgba(255,123,138,0.12);
+      outline: none;
+    }
+    #changelist-search input[type="submit"] {
+      padding: 8px 16px !important;
+      font-size: 0.78rem !important;
     }
 
-    .changelist-filters a:hover {
-      background: rgba(255, 123, 138, 0.1);
-      color: #ff5566;
-    }
+    /* ── 날짜 계층 ── */
+    .xfull { width: 100%; }
+    .date-hierarchy { margin-bottom: 14px; }
 
-    .changelist-filters a.selected {
-      background: #ff7b8a;
-      color: white;
-      font-weight: 600;
-    }
-
-    /* ── 변경 목록 테이블 ────────────────────────────────────────── */
+    /* ── 메인 영역 (필터 있을 때) ── */
     #changelist {
-      clear: left;
+      display: block;
+    }
+    #changelist.filtered { clear: left; }
+
+    /* ── 액션 폼 ── */
+    .actions {
+      background: #fff5f6;
+      border: 1px solid #f5dde0;
+      border-radius: var(--radius);
+      padding: 10px 14px;
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+    .actions label {
+      font-size: 0.78rem;
+      font-weight: 600;
+      color: #3a2028;
+    }
+    .actions select {
+      padding: 6px 10px;
+      border: 1px solid #e8d8db;
+      border-radius: var(--radius);
+      font-size: 0.78rem;
+      font-family: inherit;
+    }
+    .actions button[type="submit"] {
+      padding: 6px 14px !important;
+      font-size: 0.78rem !important;
+    }
+    .action-counter {
+      font-size: 0.72rem;
+      color: #a07080;
     }
 
-    #changelist table {
+    /* ── 테이블 ── */
+    #result_list {
       width: 100%;
       border-collapse: collapse;
+      font-size: 0.82rem;
     }
-
-    #changelist thead th {
-      background: #f8f5f2;
-      color: #2a2420;
-      padding: 15px;
+    #result_list thead th {
+      background: #fff5f6;
+      color: #7a3040;
+      padding: 10px 14px;
       text-align: left;
-      font-weight: 600;
-      border-bottom: 2px solid #ff7b8a;
-      font-size: 13px;
+      font-size: 0.65rem;
+      font-weight: 700;
       text-transform: uppercase;
-      letter-spacing: 0.5px;
+      letter-spacing: 0.07em;
+      border-bottom: 2px solid #f5dde0;
+      white-space: nowrap;
+    }
+    #result_list thead th a:link,
+    #result_list thead th a:visited {
+      color: #c04060 !important;
+      text-decoration: none !important;
+    }
+    #result_list thead th a:hover { color: #ff5566 !important; }
+
+    #result_list thead th.sorted {
+      background: #ffeef0;
+    }
+    #result_list thead th.sorted .text span.small {
+      color: #ff7b8a !important;
     }
 
-    #changelist tbody tr {
-      border-bottom: 1px solid #eee;
-      transition: background-color 0.2s ease;
+    #result_list tbody tr {
+      border-bottom: 1px solid #f9eef0;
+      transition: background 0.12s;
     }
+    #result_list tbody tr:hover { background: rgba(255,123,138,0.04); }
+    #result_list tbody tr.selected { background: #fff0f1 !important; }
 
-    #changelist tbody tr:hover {
-      background-color: rgba(255, 123, 138, 0.05);
+    #result_list td {
+      padding: 10px 14px;
+      color: #3a2028;
+      vertical-align: middle;
     }
+    #result_list td a:link,
+    #result_list td a:visited { color: #e05060 !important; font-weight: 500; }
+    #result_list td a:hover   { color: #c03040 !important; }
 
-    #changelist td {
-      padding: 15px;
-      color: #555;
-    }
+    #result_list td.field-checkbox { width: 20px; text-align: center; }
 
-    #changelist .field-checkbox {
-      text-align: center;
-    }
+    /* 불리언 아이콘 */
+    .yes-icon { color: #22c55e; font-size: 1rem; }
+    .no-icon  { color: #ef4444; font-size: 1rem; }
+    img[src*="icon-yes"]  { filter: hue-rotate(300deg) saturate(0.7); }
+    img[src*="icon-no"]   { filter: hue-rotate(0deg); }
 
-    /* ── 검색 폼 및 제출 ────────────────────────────────────────── */
-    .submit-row {
-      background: white;
-      padding: 20px 0;
-      border-top: 1px solid #ddd;
-      margin-top: 20px;
-    }
-
-    .search-form {
-      margin-bottom: 20px;
-    }
-
-    .search-form input[type="text"] {
-      padding: 10px 15px;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      font-size: 14px;
-      min-width: 250px;
-    }
-
-    .search-form input[type="submit"] {
-      margin-left: 10px;
-    }
-
-    /* ── 페이지네이터 ────────────────────────────────────────── */
+    /* ── 페이지네이터 ── */
     .paginator {
-      margin-top: 20px;
-      padding: 15px 0;
-      text-align: center;
-      font-size: 14px;
+      padding: 14px 4px 4px;
+      font-size: 0.8rem;
+      color: #7a6b68;
     }
-
     .paginator a {
-      padding: 8px 12px;
-      margin: 0 2px;
-      background: white;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      text-decoration: none;
-      color: #ff7b8a;
-    }
-
-    .paginator a:hover {
-      background: #ff7b8a;
-      color: white;
-    }
-
-    .paginator .step-links {
-      display: flex;
+      display: inline-flex;
+      align-items: center;
       justify-content: center;
-      gap: 5px;
-      flex-wrap: wrap;
+      padding: 5px 11px;
+      margin: 0 1px;
+      background: #fff;
+      border: 1px solid #f0d8db;
+      border-radius: var(--radius);
+      text-decoration: none !important;
+      color: #e05060 !important;
+      font-size: 0.78rem;
+      transition: background 0.13s;
+    }
+    .paginator a:hover { background: #fff0f1 !important; color: #c03040 !important; }
+    .paginator .this-page {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 5px 11px;
+      margin: 0 1px;
+      background: #ff7b8a;
+      border: 1px solid #ff7b8a;
+      border-radius: var(--radius);
+      color: #fff;
+      font-size: 0.78rem;
+      font-weight: 600;
+    }
+
+    /* ── 필터 사이드바 ── */
+    #changelist-filter {
+      float: right;
+      width: 220px;
+      margin-left: 20px;
+    }
+    #changelist-filter h2 {
+      font-size: 0.62rem !important;
+      font-weight: 700 !important;
+      text-transform: uppercase !important;
+      letter-spacing: 0.09em !important;
+      color: #ffffff !important;
+      background: #ff7b8a !important;
+      padding: 10px 14px !important;
+      margin: 0 !important;
+      border-radius: var(--radius) var(--radius) 0 0 !important;
+    }
+    #changelist-filter h3 {
+      font-size: 0.65rem !important;
+      font-weight: 700 !important;
+      text-transform: uppercase !important;
+      letter-spacing: 0.07em !important;
+      color: #c04060;
+      padding: 8px 14px 4px;
+      margin: 0;
+      border-top: 1px solid #f5dde0;
+    }
+    #changelist-filter ul {
+      padding: 0 14px 10px;
+      list-style: none;
+    }
+    #changelist-filter ul li {
+      padding: 3px 0;
+    }
+    #changelist-filter ul li a {
+      font-size: 0.79rem !important;
+      color: #7a5060 !important;
+      text-decoration: none !important;
+      display: block;
+      padding: 3px 4px;
+      border-radius: 4px;
+      transition: background 0.12s;
+    }
+    #changelist-filter ul li a:hover { background: #fff0f2 !important; color: #e05060 !important; }
+    #changelist-filter ul li.selected a {
+      color: #e05060 !important;
+      font-weight: 600 !important;
+    }
+
+    /* 모듈 컨테이너 */
+    #changelist .module {
+      background: #ffffff;
+      border: 1px solid #f0e0e3 !important;
+      border-radius: 8px !important;
+      overflow: hidden;
     }
   </style>
 {% endblock %}
 
-{% block content_title %}
-  <h1>{{ cl.opts.verbose_name_plural | capfirst }}</h1>
-{% endblock %}
+{# ═══════════════════════════════════════════════════════════ #}
+{# 메인 콘텐츠 블록 (이 블록이 없으면 목록이 렌더링되지 않음) #}
+{# ═══════════════════════════════════════════════════════════ #}
+{% block content %}
+<div id="content-main">
 
-{% block search %}
-  {% search_form cl %}
-{% endblock %}
+  {# 모델별 커스텀 헤더를 삽입할 수 있는 훅 #}
+  {% block extra_header %}{% endblock %}
 
-{% block date_hierarchy %}
-  {% date_hierarchy cl %}
-{% endblock %}
+  {# 검색 폼 #}
+  {% if cl.search_fields %}
+  <div id="changelist-search">
+    {% block search %}{% search_form cl %}{% endblock %}
+  </div>
+  {% endif %}
 
-{% block filters %}
-  {% admin_list_filter cl %}
-{% endblock %}
+  {# 날짜 계층 #}
+  {% block date_hierarchy %}{% if cl.date_hierarchy %}{% date_hierarchy cl %}{% endif %}{% endblock %}
 
-{% block result_list %}
-  {% result_list cl %}
-{% endblock %}
+  {# 필터 (우측 사이드바) #}
+  {% if cl.has_filters %}
+  <div id="changelist-filter">
+    {% block filters %}
+    <h2>{% trans "Filter" %}</h2>
+    {% for spec in cl.filter_specs %}{% admin_list_filter cl spec %}{% endfor %}
+    {% endblock %}
+  </div>
+  {% endif %}
 
-{% block pagination %}
-  {% pagination cl %}
+  {# 결과 목록 + 액션 #}
+  <div id="changelist" class="module{% if cl.has_filters %} filtered{% endif %}">
+    {% block result_list %}
+      {% if action_form and actions_on_top and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+      {% result_list cl %}
+      {% if action_form and actions_on_bottom and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+    {% endblock %}
+    {% block pagination %}{% pagination cl %}{% endblock %}
+  </div>
+
+</div>
 {% endblock %}

--- a/backend/templates/admin/chat/chatmemory/change_list.html
+++ b/backend/templates/admin/chat/chatmemory/change_list.html
@@ -1,0 +1,127 @@
+{% extends "admin/change_list.html" %}
+
+{% block extra_header %}
+<style>
+  .chatmem-header {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 14px;
+    margin-bottom: 20px;
+    align-items: start;
+  }
+  @media (max-width: 700px) { .chatmem-header { grid-template-columns: 1fr; } }
+
+  .chatmem-info {
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    border-radius: 10px;
+    padding: 16px 20px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+  }
+  .chatmem-info h2 {
+    font-size: 0.86rem;
+    font-weight: 700;
+    color: #2a1018;
+    margin: 0 0 5px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .chatmem-info h2 svg {
+    width: 15px; height: 15px;
+    stroke: #8b5cf6; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .chatmem-info p {
+    font-size: 0.74rem;
+    color: #9a7080;
+    margin: 0 0 10px;
+    line-height: 1.5;
+  }
+
+  .chatmem-fields {
+    display: flex;
+    gap: 7px;
+    flex-wrap: wrap;
+  }
+  .cm-chip {
+    font-size: 0.7rem;
+    background: #f5f3ff;
+    border: 1px solid #ddd6fe;
+    border-radius: 5px;
+    padding: 4px 10px;
+    color: #5b21b6;
+  }
+  .cm-chip strong { color: #7c3aed; font-weight: 700; }
+
+  /* 통계 박스 */
+  .chatmem-stats {
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    border-radius: 10px;
+    padding: 14px 18px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+    min-width: 170px;
+  }
+  .chatmem-stats .stat-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 0;
+    border-bottom: 1px solid #f9eef0;
+    font-size: 0.76rem;
+  }
+  .chatmem-stats .stat-row:last-child { border-bottom: none; }
+  .stat-label-sm { color: #9a7080; }
+  .stat-val-sm { font-weight: 700; color: #2a1018; }
+
+  .auto-gen-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: #f5f3ff;
+    border: 1px solid #ddd6fe;
+    color: #7c3aed;
+    font-size: 0.64rem;
+    font-weight: 700;
+    padding: 3px 9px;
+    border-radius: 20px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+</style>
+
+<div class="chatmem-header">
+  <div class="chatmem-info">
+    <h2>
+      <svg viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg>
+      채팅 메모리 (ChatMemory)
+      <span class="auto-gen-badge">자동 생성</span>
+    </h2>
+    <p>
+      각 채팅 세션 종료 후 AI 엔진이 자동으로 생성하는 <strong>대화 요약 메모리</strong>입니다.<br>
+      다음 세션에서 하리가 유저를 기억하는 데 사용됩니다. 수동 편집은 권장하지 않습니다.
+    </p>
+    <div class="chatmem-fields">
+      <span class="cm-chip"><strong>summary</strong> 세션 대화 요약</span>
+      <span class="cm-chip"><strong>keywords</strong> 핵심 키워드 (쉼표 구분)</span>
+      <span class="cm-chip"><strong>session_id</strong> 연결된 세션 ID</span>
+      <span class="cm-chip"><strong>ended_at</strong> 세션 종료 시각</span>
+    </div>
+  </div>
+
+  <div class="chatmem-stats">
+    <div class="stat-row">
+      <span class="stat-label-sm">전체 메모리</span>
+      <span class="stat-val-sm">{{ cl.queryset.count|default:"—" }}</span>
+    </div>
+    <div class="stat-row">
+      <span class="stat-label-sm">필터 결과</span>
+      <span class="stat-val-sm">{{ cl.result_count|default:"—" }}</span>
+    </div>
+    <div class="stat-row" style="border-top: 1px solid #f0e0e3; margin-top: 4px; padding-top: 8px;">
+      <span style="font-size:0.68rem; color:#c0a0b0;">유저 메모리 초기화는<br>유저 상세에서 수행</span>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/backend/templates/admin/chat/generatedcontent/change_list.html
+++ b/backend/templates/admin/chat/generatedcontent/change_list.html
@@ -1,0 +1,184 @@
+{% extends "admin/change_list.html" %}
+
+{% block extra_header %}
+<style>
+  .gc-header {
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    border-radius: 10px;
+    padding: 18px 22px;
+    margin-bottom: 20px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+  }
+  .gc-header-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-bottom: 14px;
+  }
+  .gc-header h2 {
+    font-size: 0.86rem;
+    font-weight: 700;
+    color: #2a1018;
+    margin: 0 0 5px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .gc-header h2 svg {
+    width: 15px; height: 15px;
+    stroke: #e05060; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .gc-header p {
+    font-size: 0.74rem;
+    color: #9a7080;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* 플랫폼 태그 */
+  .gc-platforms {
+    display: flex;
+    gap: 7px;
+    flex-wrap: wrap;
+    margin-bottom: 14px;
+  }
+  .plat-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 0.69rem;
+    font-weight: 600;
+    padding: 4px 11px;
+    border-radius: 20px;
+    border: 1px solid transparent;
+  }
+  .plat-chip.instagram { background: #fff0f5; color: #c2185b; border-color: #f8bbd0; }
+  .plat-chip.twitter   { background: #e8f5fe; color: #0277bd; border-color: #b3e5fc; }
+  .plat-chip.youtube   { background: #fff8e1; color: #e65100; border-color: #ffe0b2; }
+  .plat-chip.tiktok    { background: #f3e5f5; color: #6a1b9a; border-color: #e1bee7; }
+  .plat-chip.blog      { background: #e8f5e9; color: #2e7d32; border-color: #c8e6c9; }
+
+  /* 상태 컬럼 안내 */
+  .gc-status-guide {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 14px;
+  }
+  .status-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 0.71rem;
+    color: #7a5060;
+  }
+  .status-dot {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .status-dot.published { background: #22c55e; }
+  .status-dot.draft     { background: #f59e0b; }
+  .status-dot.archived  { background: #94a3b8; }
+
+  /* 통계 */
+  .gc-stats {
+    background: #fdf8f9;
+    border: 1px solid #f0e0e3;
+    border-radius: 8px;
+    padding: 12px 16px;
+    display: flex;
+    gap: 20px;
+    flex-wrap: wrap;
+  }
+  .gc-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .gc-stat .val { font-size: 1.1rem; font-weight: 700; color: #2a1018; }
+  .gc-stat .lbl { font-size: 0.65rem; color: #9a7080; text-transform: uppercase; letter-spacing: 0.06em; }
+
+  /* 주의 배너 */
+  .gc-notice {
+    background: #fffbeb;
+    border: 1px solid #fde68a;
+    border-left: 4px solid #f59e0b;
+    border-radius: 6px;
+    padding: 9px 13px;
+    font-size: 0.73rem;
+    color: #92400e;
+    margin-top: 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .gc-notice svg {
+    width: 13px; height: 13px;
+    stroke: #d97706; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+    flex-shrink: 0;
+  }
+</style>
+
+<div class="gc-header">
+  <div class="gc-header-top">
+    <div>
+      <h2>
+        <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+        생성 콘텐츠 관리 (GeneratedContent)
+      </h2>
+      <p>
+        하리 AI가 생성한 SNS 콘텐츠 초안입니다. <strong>is_published</strong>를 ON으로 전환하면 해당 콘텐츠가 실제 피드에 노출됩니다.<br>
+        각 콘텐츠는 플랫폼·카테고리·게시 상태로 분류됩니다.
+      </p>
+    </div>
+  </div>
+
+  <div class="gc-platforms">
+    <span class="plat-chip instagram">
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"/></svg>
+      Instagram
+    </span>
+    <span class="plat-chip twitter">
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z"/></svg>
+      Twitter / X
+    </span>
+    <span class="plat-chip youtube">
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22.54 6.42a2.78 2.78 0 0 0-1.95-1.96C18.88 4 12 4 12 4s-6.88 0-8.59.46a2.78 2.78 0 0 0-1.95 1.96A29 29 0 0 0 1 11.75a29 29 0 0 0 .46 5.33A2.78 2.78 0 0 0 3.41 19c1.71.46 8.59.46 8.59.46s6.88 0 8.59-.46a2.78 2.78 0 0 0 1.95-1.95 29 29 0 0 0 .46-5.25 29 29 0 0 0-.46-5.33z"/><polygon points="9.75 15.02 15.5 11.75 9.75 8.48 9.75 15.02"/></svg>
+      YouTube
+    </span>
+    <span class="plat-chip tiktok">TikTok</span>
+    <span class="plat-chip blog">블로그</span>
+  </div>
+
+  <div class="gc-status-guide">
+    <div class="status-item"><span class="status-dot published"></span>is_published = ON → 피드 노출</div>
+    <div class="status-item"><span class="status-dot draft"></span>is_published = OFF → 초안 (비공개)</div>
+    <div class="status-item"><span class="status-dot archived"></span>삭제 = 영구 삭제 (복구 불가)</div>
+  </div>
+
+  <div class="gc-stats">
+    <div class="gc-stat">
+      <span class="val">{{ cl.queryset.count|default:"—" }}</span>
+      <span class="lbl">전체 콘텐츠</span>
+    </div>
+    <div class="gc-stat">
+      <span class="val">{{ cl.result_count|default:"—" }}</span>
+      <span class="lbl">필터 결과</span>
+    </div>
+  </div>
+
+  <div class="gc-notice">
+    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+    <span>
+      <strong>is_published</strong> 전환 시 즉시 프론트엔드에 반영됩니다. 내용 검토 후 게시하세요.
+      AI 생성 콘텐츠는 자동 게시되지 않으며, 반드시 관리자 승인(is_published = ON)이 필요합니다.
+    </span>
+  </div>
+</div>
+{% endblock %}

--- a/backend/templates/admin/chat/hariknowledge/change_list.html
+++ b/backend/templates/admin/chat/hariknowledge/change_list.html
@@ -1,0 +1,155 @@
+{% extends "admin/change_list.html" %}
+{% load static %}
+
+{% block extra_header %}
+<style>
+  /* ── 하리 지식 헤더 ── */
+  .knowledge-header {
+    background: linear-gradient(135deg, #1a1018 0%, #1e0a20 100%);
+    border: 1px solid rgba(255,123,138,0.2);
+    border-radius: 10px;
+    padding: 20px 24px;
+    margin-bottom: 22px;
+  }
+  .knowledge-header-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 16px;
+    flex-wrap: wrap;
+  }
+  .knowledge-header h2 {
+    font-size: 0.88rem;
+    font-weight: 700;
+    color: #f8fafc;
+    margin: 0 0 6px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .knowledge-header h2 svg {
+    width: 15px; height: 15px;
+    stroke: #ff7b8a; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .knowledge-header > p {
+    font-size: 0.74rem;
+    color: rgba(248,250,252,0.4);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* 카테고리 설명 */
+  .knowledge-categories {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .cat-chip {
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 20px;
+    padding: 4px 12px;
+    font-size: 0.7rem;
+    color: rgba(248,250,252,0.55);
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+  .cat-chip::before {
+    content: '';
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: #ff7b8a;
+    flex-shrink: 0;
+  }
+  .cat-chip.cat-persona::before  { background: #f59e0b; }
+  .cat-chip.cat-speech::before   { background: #22c55e; }
+  .cat-chip.cat-history::before  { background: #8b5cf6; }
+  .cat-chip.cat-relation::before { background: #06b6d4; }
+
+  .knowledge-actions {
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+  .knowledge-actions a {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 14px;
+    border-radius: 6px;
+    font-size: 0.74rem;
+    font-weight: 600;
+    text-decoration: none !important;
+    transition: opacity 0.14s;
+  }
+  .knowledge-actions a:hover { opacity: 0.85; }
+  .btn-add-knowledge {
+    background: #ff7b8a;
+    color: #fff !important;
+  }
+
+  /* 경고 배너 */
+  .knowledge-warning {
+    background: rgba(239,68,68,0.08);
+    border: 1px solid rgba(239,68,68,0.2);
+    border-radius: 6px;
+    padding: 10px 14px;
+    font-size: 0.73rem;
+    color: rgba(255,150,150,0.8);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .knowledge-warning svg {
+    width: 14px; height: 14px;
+    stroke: rgba(255,100,100,0.7); fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+    flex-shrink: 0;
+  }
+</style>
+
+<div class="knowledge-header">
+  <div class="knowledge-header-top">
+    <div>
+      <h2>
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        하리 지식 (Hari Knowledge)
+      </h2>
+      <p style="font-size:0.74rem; color:rgba(248,250,252,0.4); margin:0; line-height:1.5;">
+        하리의 페르소나, 말투, 역사, 관계를 정의하는 지식 베이스입니다.<br>
+        <strong style="color:rgba(255,123,138,0.8)">is_active = OFF</strong>인 항목은 하리 엔진에서 무시됩니다.
+        weight 필드는 pgvector 임베딩 — 직접 수정 금지.
+      </p>
+    </div>
+    <div class="knowledge-actions">
+      <a href="add/" class="btn-add-knowledge">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        지식 추가
+      </a>
+    </div>
+  </div>
+
+  <div class="knowledge-categories">
+    <span class="cat-chip cat-persona">persona — 하리의 성격·자아</span>
+    <span class="cat-chip cat-speech">speech — 말투·어조</span>
+    <span class="cat-chip cat-history">history — 배경 스토리</span>
+    <span class="cat-chip cat-relation">relation — 인물 관계</span>
+    <span class="cat-chip">preference — 취향·관심사</span>
+    <span class="cat-chip">world — 세계관 설정</span>
+  </div>
+
+  <div style="height:12px;"></div>
+
+  <div class="knowledge-warning">
+    <svg viewBox="0 0 24 24"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+    <span>
+      <strong>weight 필드 수정 금지</strong> — pgvector 임베딩 값은 백엔드 엔진이 자동 생성합니다.
+      직접 수정 시 벡터 검색이 깨질 수 있습니다.
+      trait_value만 수정하세요.
+    </span>
+  </div>
+</div>
+{% endblock %}

--- a/backend/templates/admin/chat/message/change_list.html
+++ b/backend/templates/admin/chat/message/change_list.html
@@ -1,0 +1,134 @@
+{% extends "admin/change_list.html" %}
+{% load static %}
+
+{% block extra_header %}
+<style>
+  /* ── 채팅 모니터링 헤더 ── */
+  .chat-monitor-header {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 16px;
+    margin-bottom: 20px;
+    align-items: start;
+  }
+
+  /* 프라이버시 경고 */
+  .privacy-warning {
+    background: #fffbeb;
+    border: 1px solid #fde68a;
+    border-left: 4px solid #f59e0b;
+    border-radius: 8px;
+    padding: 14px 18px;
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+  }
+  .privacy-warning svg {
+    width: 18px; height: 18px;
+    stroke: #d97706; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+  .privacy-warning-text strong {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: #92400e;
+    margin-bottom: 4px;
+  }
+  .privacy-warning-text p {
+    font-size: 0.74rem;
+    color: #b45309;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* 통계 카드 */
+  .chat-stats {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 180px;
+  }
+  .chat-stat-card {
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    border-radius: 7px;
+    padding: 10px 14px;
+    text-align: right;
+  }
+  .chat-stat-card .stat-label {
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #c04060;
+    display: block;
+    margin-bottom: 3px;
+  }
+  .chat-stat-card .stat-value {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #2a1018;
+  }
+
+  /* 발신자 유형 뱃지 */
+  .sender-user {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 20px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    background: #eff6ff;
+    color: #2563eb;
+  }
+  .sender-hari {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 20px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    background: #fff0f1;
+    color: #e05060;
+  }
+
+  /* 읽음 상태 */
+  .read-yes { color: #22c55e !important; }
+  .read-no  { color: #94a3b8 !important; }
+</style>
+
+<div class="chat-monitor-header">
+  <div class="privacy-warning">
+    <svg viewBox="0 0 24 24"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+    <div class="privacy-warning-text">
+      <strong>개인정보 보호 주의</strong>
+      <p>
+        이 페이지에서 열람하는 채팅 내용은 유저의 개인 대화입니다.<br>
+        관리자 접근은 자동으로 기록되며, 업무 목적 외 열람은 금지됩니다.<br>
+        <em>백엔드 요청: AdminAccessLog 미들웨어 연동 필요 (BACKEND_REQUEST.md 참고)</em>
+      </p>
+    </div>
+  </div>
+
+  <div class="chat-stats">
+    <div class="chat-stat-card">
+      <span class="stat-label">전체 메시지</span>
+      <span class="stat-value">{{ cl.queryset.count|default:"—" }}</span>
+    </div>
+    <div class="chat-stat-card">
+      <span class="stat-label">현재 필터 결과</span>
+      <span class="stat-value">{{ cl.result_count|default:"—" }}</span>
+    </div>
+  </div>
+</div>
+
+<div style="font-size:0.74rem; color:#a07080; margin-bottom:14px; padding-left:2px;">
+  💡 <strong>발신자 유형:</strong> True = 유저 발신 &nbsp;|&nbsp; False = 하리 발신 &nbsp;&nbsp;
+  <strong>검색:</strong> 닉네임 또는 메시지 내용으로 필터링
+</div>
+{% endblock %}

--- a/backend/templates/admin/chat/userpersona/change_list.html
+++ b/backend/templates/admin/chat/userpersona/change_list.html
@@ -1,0 +1,193 @@
+{% extends "admin/change_list.html" %}
+
+{% block extra_header %}
+<style>
+  .persona-header {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 14px;
+    margin-bottom: 20px;
+    align-items: start;
+  }
+  @media (max-width: 700px) { .persona-header { grid-template-columns: 1fr; } }
+
+  .persona-info {
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    border-radius: 10px;
+    padding: 16px 20px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+  }
+  .persona-info h2 {
+    font-size: 0.86rem;
+    font-weight: 700;
+    color: #2a1018;
+    margin: 0 0 5px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .persona-info h2 svg {
+    width: 15px; height: 15px;
+    stroke: #e05060; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .persona-info p {
+    font-size: 0.74rem;
+    color: #9a7080;
+    margin: 0 0 12px;
+    line-height: 1.5;
+  }
+
+  /* 자동생성 배지 */
+  .auto-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: #fff0f5;
+    border: 1px solid #fecdd3;
+    color: #e11d48;
+    font-size: 0.62rem;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 20px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  /* 필드 카드 */
+  .persona-fields {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 7px;
+  }
+  .pf-card {
+    background: #fdf8f9;
+    border: 1px solid #f0e0e3;
+    border-radius: 7px;
+    padding: 8px 11px;
+  }
+  .pf-card .pf-name {
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #c04060;
+    display: block;
+    margin-bottom: 3px;
+  }
+  .pf-card .pf-desc {
+    font-size: 0.7rem;
+    color: #8a6070;
+    line-height: 1.35;
+  }
+
+  /* 통계 박스 */
+  .persona-stats {
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    border-radius: 10px;
+    padding: 14px 18px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+    min-width: 165px;
+  }
+  .persona-stats .stat-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 0;
+    border-bottom: 1px solid #f9eef0;
+    font-size: 0.76rem;
+  }
+  .persona-stats .stat-row:last-child { border-bottom: none; }
+  .stat-label { color: #9a7080; }
+  .stat-val { font-weight: 700; color: #2a1018; }
+
+  /* 경고 */
+  .persona-warning {
+    background: #fffbeb;
+    border: 1px solid #fde68a;
+    border-left: 4px solid #f59e0b;
+    border-radius: 6px;
+    padding: 9px 13px;
+    font-size: 0.73rem;
+    color: #92400e;
+    margin-top: 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .persona-warning svg {
+    width: 13px; height: 13px;
+    stroke: #d97706; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+    flex-shrink: 0;
+  }
+</style>
+
+<div class="persona-header">
+  <div class="persona-info">
+    <h2>
+      <svg viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+      유저 페르소나 (UserPersona)
+      <span class="auto-badge">AI 분석</span>
+    </h2>
+    <p>
+      채팅 AI가 유저의 대화 패턴·관심사·감정 상태를 분석해 자동으로 구축하는 <strong>유저 모델</strong>입니다.<br>
+      하리가 유저를 개인화된 방식으로 대응하는 데 사용됩니다. 수동 편집은 권장하지 않습니다.
+    </p>
+    <div class="persona-fields">
+      <div class="pf-card">
+        <span class="pf-name">nickname</span>
+        <span class="pf-desc">유저가 선호하는 호칭</span>
+      </div>
+      <div class="pf-card">
+        <span class="pf-name">personality_tags</span>
+        <span class="pf-desc">성격 특성 태그 (JSON 배열)</span>
+      </div>
+      <div class="pf-card">
+        <span class="pf-name">interests</span>
+        <span class="pf-desc">관심사·취미 목록</span>
+      </div>
+      <div class="pf-card">
+        <span class="pf-name">emotional_state</span>
+        <span class="pf-desc">최근 감정 상태 요약</span>
+      </div>
+      <div class="pf-card">
+        <span class="pf-name">relationship_level</span>
+        <span class="pf-desc">하리와의 친밀도 단계</span>
+      </div>
+      <div class="pf-card">
+        <span class="pf-name">updated_at</span>
+        <span class="pf-desc">마지막 분석 갱신 시각</span>
+      </div>
+    </div>
+
+    <div class="persona-warning" style="margin-top: 12px;">
+      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+      <span>
+        페르소나 데이터는 채팅 AI가 지속적으로 갱신합니다.
+        수동으로 편집할 경우 다음 분석 사이클에서 덮어쓰여질 수 있습니다.
+        <strong>유저 페르소나 초기화</strong>는 유저 상세 페이지에서 수행하세요.
+      </span>
+    </div>
+  </div>
+
+  <div class="persona-stats">
+    <div class="stat-row">
+      <span class="stat-label">전체 페르소나</span>
+      <span class="stat-val">{{ cl.queryset.count|default:"—" }}</span>
+    </div>
+    <div class="stat-row">
+      <span class="stat-label">필터 결과</span>
+      <span class="stat-val">{{ cl.result_count|default:"—" }}</span>
+    </div>
+    <div class="stat-row" style="border-top: 1px solid #f0e0e3; margin-top: 4px; padding-top: 8px; display: block;">
+      <span style="font-size: 0.66rem; color: #c0a0b0; line-height: 1.4; display: block;">
+        유저 1명당 페르소나 1개<br>
+        (user — OneToOne)
+      </span>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/backend/templates/admin/chat/visitlog/change_list.html
+++ b/backend/templates/admin/chat/visitlog/change_list.html
@@ -1,0 +1,150 @@
+{% extends "admin/change_list.html" %}
+
+{% block extra_header %}
+<style>
+  .vl-header {
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    border-radius: 10px;
+    padding: 18px 22px;
+    margin-bottom: 20px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+  }
+  .vl-header-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-bottom: 14px;
+  }
+  .vl-header h2 {
+    font-size: 0.86rem;
+    font-weight: 700;
+    color: #2a1018;
+    margin: 0 0 5px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .vl-header h2 svg {
+    width: 15px; height: 15px;
+    stroke: #e05060; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .vl-header p {
+    font-size: 0.74rem;
+    color: #9a7080;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* 통계 그리드 */
+  .vl-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    gap: 8px;
+    margin-bottom: 14px;
+  }
+  .vl-stat-card {
+    background: #fdf8f9;
+    border: 1px solid #f0e0e3;
+    border-radius: 8px;
+    padding: 10px 14px;
+    text-align: center;
+  }
+  .vl-stat-card .val {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: #2a1018;
+    display: block;
+  }
+  .vl-stat-card .lbl {
+    font-size: 0.63rem;
+    color: #9a7080;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-top: 2px;
+    display: block;
+  }
+
+  /* 필드 칩 */
+  .vl-fields {
+    display: flex;
+    gap: 7px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+  }
+  .vl-chip {
+    font-size: 0.7rem;
+    background: #fdf4f5;
+    border: 1px solid #f0e0e3;
+    border-radius: 5px;
+    padding: 4px 10px;
+    color: #7a5060;
+  }
+  .vl-chip strong { color: #c04060; }
+
+  /* 안내 */
+  .vl-note {
+    background: #f0fdf4;
+    border: 1px solid #bbf7d0;
+    border-left: 4px solid #22c55e;
+    border-radius: 6px;
+    padding: 9px 13px;
+    font-size: 0.73rem;
+    color: #166534;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .vl-note svg {
+    width: 13px; height: 13px;
+    stroke: #16a34a; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+    flex-shrink: 0;
+  }
+</style>
+
+<div class="vl-header">
+  <div class="vl-header-top">
+    <div>
+      <h2>
+        <svg viewBox="0 0 24 24"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+        방문 로그 (VisitLog)
+      </h2>
+      <p>
+        사이트 방문 기록입니다. 유저 행동 분석 및 트래픽 모니터링에 활용됩니다.<br>
+        개인정보 보호를 위해 IP는 부분 마스킹 처리 후 저장됩니다.
+      </p>
+    </div>
+  </div>
+
+  <div class="vl-stats">
+    <div class="vl-stat-card">
+      <span class="val">{{ cl.queryset.count|default:"—" }}</span>
+      <span class="lbl">전체 로그</span>
+    </div>
+    <div class="vl-stat-card">
+      <span class="val">{{ cl.result_count|default:"—" }}</span>
+      <span class="lbl">필터 결과</span>
+    </div>
+  </div>
+
+  <div class="vl-fields">
+    <span class="vl-chip"><strong>user</strong> 방문 유저 (null = 비로그인)</span>
+    <span class="vl-chip"><strong>path</strong> 방문 경로 (URL)</span>
+    <span class="vl-chip"><strong>ip_address</strong> 부분 마스킹 IP</span>
+    <span class="vl-chip"><strong>user_agent</strong> 브라우저·기기 정보</span>
+    <span class="vl-chip"><strong>visited_at</strong> 방문 일시</span>
+  </div>
+
+  <div class="vl-note">
+    <svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>
+    <span>
+      방문 로그는 자동 수집되며 수동 편집은 불필요합니다.
+      오래된 로그 일괄 삭제 시 필터로 기간을 선택 후 액션 메뉴를 사용하세요.
+    </span>
+  </div>
+</div>
+{% endblock %}

--- a/backend/templates/admin/delete_confirmation.html
+++ b/backend/templates/admin/delete_confirmation.html
@@ -1,0 +1,221 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block title %}삭제 확인 | HARI 관리자{% endblock %}
+
+{% block content %}
+<style>
+  .delete-wrap { max-width: 700px; }
+
+  /* 경고 배너 */
+  .delete-banner {
+    background: #fff5f5;
+    border: 1px solid #fecaca;
+    border-left: 5px solid #ef4444;
+    border-radius: 10px;
+    padding: 20px 24px;
+    margin-bottom: 24px;
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+  }
+  .delete-banner-icon {
+    width: 40px; height: 40px;
+    border-radius: 50%;
+    background: #fee2e2;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+  .delete-banner-icon svg {
+    width: 20px; height: 20px;
+    stroke: #ef4444; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .delete-banner-text h2 {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: #991b1b;
+    margin: 0 0 6px;
+  }
+  .delete-banner-text p {
+    font-size: 0.8rem;
+    color: #b91c1c;
+    margin: 0;
+    line-height: 1.5;
+  }
+  .delete-banner-text .obj-name {
+    font-weight: 700;
+    background: #fee2e2;
+    border-radius: 4px;
+    padding: 2px 6px;
+  }
+
+  /* 연관 삭제 목록 */
+  .related-section {
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 20px;
+  }
+  .related-section-header {
+    padding: 10px 18px;
+    background: #fff8f8;
+    border-bottom: 1px solid #f5dde0;
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    color: #c04060;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+  }
+  .related-section-header svg {
+    width: 12px; height: 12px;
+    stroke: currentColor; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .related-list {
+    padding: 12px 18px;
+    font-size: 0.8rem;
+    color: #5a3040;
+    line-height: 1.7;
+  }
+  .related-list ul { padding-left: 16px; }
+  .related-list ul li { margin-bottom: 4px; }
+
+  /* 권한 부족 경고 */
+  .perms-warning {
+    background: #fffbeb;
+    border: 1px solid #fde68a;
+    border-radius: 8px;
+    padding: 14px 18px;
+    font-size: 0.8rem;
+    color: #92400e;
+    margin-bottom: 20px;
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+  }
+  .perms-warning svg {
+    width: 16px; height: 16px;
+    stroke: #d97706; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+    flex-shrink: 0; margin-top: 1px;
+  }
+
+  /* 보호된 객체 */
+  .protected-warning {
+    background: #f0fdf4;
+    border: 1px solid #bbf7d0;
+    border-radius: 8px;
+    padding: 14px 18px;
+    font-size: 0.8rem;
+    color: #166534;
+    margin-bottom: 20px;
+  }
+
+  /* 버튼 영역 */
+  .delete-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 18px 0 4px;
+    flex-wrap: wrap;
+  }
+  .btn-confirm-delete {
+    background: #ef4444 !important;
+    border-color: #ef4444 !important;
+    color: #fff !important;
+    padding: 10px 28px !important;
+    font-size: 0.84rem !important;
+    font-weight: 600 !important;
+    border-radius: var(--radius) !important;
+    cursor: pointer;
+    transition: background 0.14s !important;
+  }
+  .btn-confirm-delete:hover { background: #dc2626 !important; }
+  .btn-cancel {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 20px;
+    border: 1px solid #f0e0e3;
+    border-radius: var(--radius);
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: #7a5060 !important;
+    text-decoration: none !important;
+    background: #fff;
+    transition: background 0.13s;
+  }
+  .btn-cancel:hover { background: #fff5f6 !important; color: #5a3040 !important; }
+</style>
+
+<div class="delete-wrap">
+
+  <!-- 경고 배너 -->
+  <div class="delete-banner">
+    <div class="delete-banner-icon">
+      <svg viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>
+    </div>
+    <div class="delete-banner-text">
+      <h2>정말 삭제하시겠습니까?</h2>
+      <p>
+        <span class="obj-name">{{ object }}</span>
+        {% blocktrans with escaped_object=object %}
+        을(를) 삭제하려고 합니다. 이 작업은 <strong>되돌릴 수 없습니다.</strong>
+        {% endblocktrans %}
+      </p>
+    </div>
+  </div>
+
+  <!-- 연관 삭제 목록 -->
+  {% if deleted_objects %}
+  <div class="related-section">
+    <div class="related-section-header">
+      <svg viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      함께 삭제되는 관련 데이터
+    </div>
+    <div class="related-list">
+      {{ deleted_objects }}
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- 권한 부족 경고 -->
+  {% if perms_lacking %}
+  <div class="perms-warning">
+    <svg viewBox="0 0 24 24"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+    <span>
+      <strong>삭제 권한 부족</strong> — 아래 관련 항목에 대한 삭제 권한이 없습니다:<br>
+      {{ perms_lacking }}
+    </span>
+  </div>
+  {% endif %}
+
+  <!-- 보호 객체 경고 -->
+  {% if protected %}
+  <div class="protected-warning">
+    <strong>삭제 보호됨</strong> — 아래 항목이 이 객체를 참조하고 있어 삭제할 수 없습니다:<br>
+    {{ protected }}
+  </div>
+  {% endif %}
+
+  <!-- 버튼 -->
+  <form method="post">
+    {% csrf_token %}
+    <div class="delete-actions">
+      {% if not protected and not perms_lacking %}
+        <input type="submit" class="btn-confirm-delete" value="예, 삭제합니다">
+      {% endif %}
+      <a href="../" class="btn-cancel">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
+        취소 (되돌아가기)
+      </a>
+    </div>
+  </form>
+
+</div>
+{% endblock %}

--- a/backend/templates/admin/index.html
+++ b/backend/templates/admin/index.html
@@ -1,67 +1,90 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_urls %}
+{% load i18n admin_urls static %}
 
 {% block title %}대시보드 | HARI Admin{% endblock %}
 
 {% block content %}
 <style>
-  /* ── 대시보드 헤더 (연분홍) ── */
-  .dash-header {
-    background: #fff0f2;
-    border: 1px solid #ffc9ce;
+  /* ── 페이지 레이아웃 ── */
+  .dash-wrap {
+    max-width: 1200px;
+  }
+
+  /* ── 웰컴 배너 ── */
+  .dash-banner {
+    background: linear-gradient(135deg, #1a1018 0%, #2d1520 100%);
     border-radius: 10px;
-    padding: 22px 26px;
+    padding: 24px 28px;
     margin-bottom: 28px;
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
   }
-
-  .dash-header-text h1 {
-    font-size: 1rem;
+  .dash-banner-left h1 {
+    font-size: 1.05rem;
     font-weight: 700;
-    color: #c03048;
-    margin-bottom: 3px;
+    color: #f8fafc;
+    margin: 0 0 5px;
     letter-spacing: 0.01em;
   }
-
-  .dash-header-text p {
-    font-size: 0.75rem;
-    color: #e0808a;
+  .dash-banner-left p {
+    font-size: 0.78rem;
+    color: rgba(248,250,252,0.45);
     margin: 0;
   }
-
-  .dash-header-badge {
-    font-size: 0.68rem;
-    font-weight: 600;
-    color: #ff7b8a;
-    background: #ffffff;
-    border: 1px solid #ffc9ce;
+  .dash-banner-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .dash-badge {
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    background: rgba(245,158,11,0.18);
+    color: #f59e0b;
+    border: 1px solid rgba(245,158,11,0.3);
+    padding: 5px 13px;
     border-radius: 20px;
-    padding: 4px 12px;
-    white-space: nowrap;
+  }
+  .dash-time {
+    font-size: 0.72rem;
+    color: rgba(248,250,252,0.3);
   }
 
   /* ── 섹션 타이틀 ── */
-  .section-label {
-    font-size: 0.61rem;
+  .dash-section-title {
+    font-size: 0.62rem;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.09em;
-    color: #e06070;
-    margin-bottom: 11px;
-    padding-bottom: 6px;
+    letter-spacing: 0.1em;
+    color: #c04060;
+    margin: 0 0 10px;
+    padding-bottom: 8px;
     border-bottom: 1px solid #f5dde0;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+  }
+  .dash-section-title svg {
+    width: 13px; height: 13px;
+    stroke: currentColor; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+    opacity: 0.7;
   }
 
-  .app-section {
+  /* ── 섹션 그룹 ── */
+  .dash-section {
     margin-bottom: 28px;
   }
 
-  /* ── 모델 카드 ── */
+  /* ── 모델 카드 그리드 ── */
   .model-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
     gap: 10px;
   }
 
@@ -71,208 +94,471 @@
     border-radius: 8px;
     padding: 16px 18px;
     box-shadow: 0 1px 3px rgba(0,0,0,0.04);
-    transition: box-shadow 0.18s, border-color 0.18s;
+    transition: box-shadow 0.18s, border-color 0.18s, transform 0.18s;
+  }
+  .model-card:hover {
+    border-color: #ffc0c8;
+    box-shadow: 0 4px 14px rgba(255,100,120,0.1);
+    transform: translateY(-1px);
   }
 
-  .model-card:hover {
-    border-color: #ffb0bb;
-    box-shadow: 0 3px 12px rgba(255,100,120,0.09);
+  .model-card-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: 13px;
+    gap: 8px;
   }
+  .model-card-icon {
+    width: 32px; height: 32px;
+    border-radius: 8px;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+  .model-card-icon svg {
+    width: 15px; height: 15px;
+    stroke: currentColor; fill: none;
+    stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round;
+  }
+  /* 아이콘 컬러 변형 */
+  .icon-pink  { background: #fff0f2; color: #e05070; }
+  .icon-amber { background: #fffbeb; color: #d97706; }
+  .icon-blue  { background: #eff6ff; color: #3b82f6; }
+  .icon-green { background: #ecfdf5; color: #059669; }
+  .icon-violet{ background: #f5f3ff; color: #7c3aed; }
+  .icon-gray  { background: #f8fafc; color: #64748b; }
 
   .model-card h4 {
-    font-size: 0.84rem;
+    font-size: 0.82rem;
     font-weight: 600;
     color: #2a1018;
-    margin-bottom: 12px;
+    margin: 0;
+    line-height: 1.3;
+  }
+  .model-card .model-desc {
+    font-size: 0.71rem;
+    color: #9a8080;
+    margin: 4px 0 13px;
+    line-height: 1.4;
   }
 
   .card-actions {
     display: flex;
-    gap: 7px;
+    gap: 6px;
   }
-
   .card-actions a {
     flex: 1;
     padding: 6px 10px;
     text-align: center;
     border-radius: 5px;
-    font-size: 0.71rem;
+    font-size: 0.7rem;
     font-weight: 500;
     text-decoration: none !important;
-    transition: background 0.15s;
+    transition: background 0.14s;
+    white-space: nowrap;
   }
-
   .btn-manage {
     background: #ff7b8a;
     color: #ffffff !important;
-    border: 1px solid transparent;
   }
-
-  .btn-manage:hover {
-    background: #f56070 !important;
-    color: #ffffff !important;
-  }
-
+  .btn-manage:hover { background: #f56070 !important; color: #fff !important; }
   .btn-add {
     background: transparent;
     color: #d95060 !important;
     border: 1px solid #f0b8be;
   }
-
-  .btn-add:hover {
-    background: #fff0f2 !important;
-    color: #d95060 !important;
+  .btn-add:hover { background: #fff0f2 !important; color: #d95060 !important; }
+  .btn-disabled {
+    background: #f5f0f0;
+    color: #c0a8aa !important;
+    cursor: not-allowed;
+    pointer-events: none;
+    border: 1px solid #ede4e4;
   }
 
-  /* ── 콘텐츠 관리 섹션 ── */
-  .upcoming-section {
-    margin-bottom: 28px;
+  /* 미구현 카드 */
+  .model-card.coming-soon {
+    opacity: 0.55;
+    border-style: dashed;
   }
-
-  .upcoming-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 10px;
+  .model-card.coming-soon:hover {
+    transform: none;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+    border-color: #f0e0e3;
+  }
+  .coming-tag {
+    font-size: 0.58rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    background: #f5eeee;
+    color: #c0a0a8;
+    padding: 2px 7px;
+    border-radius: 4px;
   }
 
   /* ── 최근 활동 ── */
-  .recent-section {
+  .recent-wrap {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 28px;
+  }
+  @media (max-width: 900px) { .recent-wrap { grid-template-columns: 1fr; } }
+
+  .recent-box {
     background: #ffffff;
     border: 1px solid #f0e0e3;
     border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
     overflow: hidden;
-    margin-top: 4px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
   }
-
-  .recent-header {
-    padding: 11px 18px;
+  .recent-box-header {
+    padding: 11px 16px;
     border-bottom: 1px solid #f5dde0;
-    font-size: 0.61rem;
+    font-size: 0.62rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.09em;
-    color: #e06070;
+    color: #c04060;
     background: #fffbfb;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+  }
+  .recent-box-header svg {
+    width: 12px; height: 12px;
+    stroke: currentColor; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
   }
 
   .recent-list {
     list-style: none;
   }
-
   .recent-list li {
-    padding: 9px 18px;
+    padding: 9px 16px;
     border-bottom: 1px solid #f9eef0;
     font-size: 0.79rem;
     color: #3a2028;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 8px;
+    line-height: 1.4;
   }
-
   .recent-list li:last-child { border-bottom: none; }
   .recent-list li:hover { background: #fffbfb; }
-  .recent-list li a { color: #e06070 !important; }
-
-  .empty-msg {
-    padding: 28px;
+  .recent-list li a { color: #e06070 !important; font-weight: 500; }
+  .recent-list .action-time {
+    font-size: 0.68rem;
+    color: #c0a0a8;
+    margin-left: auto;
+    flex-shrink: 0;
+    padding-top: 1px;
+  }
+  .recent-empty {
+    padding: 28px 16px;
     text-align: center;
     color: #c9a0aa;
-    font-size: 0.79rem;
+    font-size: 0.78rem;
   }
 </style>
 
-<div id="content-main">
+<div class="dash-wrap">
 
-  <!-- ── 헤더 ── -->
-  <div class="dash-header">
-    <div class="dash-header-text">
+  <!-- ── 웰컴 배너 ── -->
+  <div class="dash-banner">
+    <div class="dash-banner-left">
       <h1>HARI 관리자 대시보드</h1>
-      <p>데이터 확인·수정·추가는 아래 모델 카드에서 진행하세요.</p>
+      <p>
+        {% if user.get_full_name %}
+          안녕하세요, {{ user.get_full_name }}님.
+        {% else %}
+          안녕하세요, {{ user.username }}님.
+        {% endif %}
+        데이터 조회·수정·추가는 아래 모델 카드를 이용하세요.
+      </p>
     </div>
-    <span class="dash-header-badge">HARI Admin</span>
-  </div>
-
-  <!-- ── 현재 활성 모델 ── -->
-  {% if app_list %}
-    {% for app in app_list %}
-      <div class="app-section">
-        <div class="section-label">{{ app.name }}</div>
-        <div class="model-grid">
-          {% for model in app.models %}
-            <div class="model-card">
-              <h4>{{ model.name }}</h4>
-              <div class="card-actions">
-                {% if model.change_url %}
-                  <a href="{{ model.change_url }}" class="btn-manage">목록 보기</a>
-                {% endif %}
-                {% if model.add_url %}
-                  <a href="{{ model.add_url }}" class="btn-add">추가</a>
-                {% endif %}
-              </div>
-            </div>
-          {% endfor %}
-        </div>
-      </div>
-    {% endfor %}
-  {% else %}
-    <div class="empty-msg">접근 가능한 모델이 없습니다.</div>
-  {% endif %}
-
-  <!-- ── 콘텐츠 관리 (백엔드 모델 생성 후 연결 예정) ── -->
-  <div class="upcoming-section">
-    <div class="section-label">콘텐츠 관리</div>
-    <div class="upcoming-grid">
-
-      <div class="model-card">
-        <h4>Gallery Images</h4>
-        <div class="card-actions">
-          <a href="#" class="btn-add">추가</a>
-        </div>
-      </div>
-
-      <div class="model-card">
-        <h4>News &amp; Events</h4>
-        <div class="card-actions">
-          <a href="#" class="btn-add">추가</a>
-        </div>
-      </div>
-
-      <div class="model-card">
-        <h4>Video Contents</h4>
-        <div class="card-actions">
-          <a href="#" class="btn-add">추가</a>
-        </div>
-      </div>
-
-      <div class="model-card">
-        <h4>Contact Submissions</h4>
-        <div class="card-actions">
-          <a href="#" class="btn-add">추가</a>
-        </div>
-      </div>
-
-      <div class="model-card">
-        <h4>User Memberships</h4>
-        <div class="card-actions">
-          <a href="#" class="btn-add">추가</a>
-        </div>
-      </div>
-
+    <div class="dash-banner-right">
+      <span class="dash-badge">Staff</span>
     </div>
   </div>
 
   <!-- ── 최근 활동 ── -->
-  {% if recent_actions %}
-    <div class="recent-section">
-      <div class="recent-header">최근 활동</div>
+  <div class="recent-wrap">
+    <div class="recent-box">
+      <div class="recent-box-header">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        최근 관리자 활동
+      </div>
+      {% if recent_actions %}
+        <ul class="recent-list">
+          {% for action in recent_actions %}
+            <li>
+              <span>{{ action }}</span>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <div class="recent-empty">아직 활동 기록이 없습니다.</div>
+      {% endif %}
+    </div>
+
+    <div class="recent-box">
+      <div class="recent-box-header">
+        <svg viewBox="0 0 24 24"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"/><path d="M12 8v4l3 3"/></svg>
+        빠른 접근
+      </div>
       <ul class="recent-list">
-        {% for action in recent_actions %}
-          <li>{{ action }}</li>
-        {% endfor %}
+        <li>
+          <a href="/admin/rpg/lorebook/add/">+ 새 시나리오(로어북) 추가</a>
+        </li>
+        <li>
+          <a href="/admin/chat/hariknowledge/add/">+ 하리 지식 추가</a>
+        </li>
+        <li>
+          <a href="/admin/auth/user/">사용자 목록 보기</a>
+        </li>
+        <li>
+          <a href="/admin/chat/message/">채팅 메시지 조회</a>
+        </li>
+        <li>
+          <a href="/admin/rpg/lorebook/">시나리오 전체 목록</a>
+        </li>
       </ul>
     </div>
-  {% endif %}
+  </div>
 
-</div>
+  <!-- ── ① 핵심 ── -->
+  <div class="dash-section">
+    <div class="dash-section-title">
+      <svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>
+      사용자 관리
+    </div>
+    <div class="model-grid">
+      {% for app in app_list %}
+        {% if app.app_label == "auth" %}
+          {% for model in app.models %}
+            {% if model.object_name == "User" %}
+              <div class="model-card">
+                <div class="model-card-header">
+                  <div class="model-card-icon icon-blue">
+                    <svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>
+                  </div>
+                </div>
+                <h4>{{ model.name }}</h4>
+                <p class="model-desc">가입 유저 계정·권한 관리</p>
+                <div class="card-actions">
+                  {% if model.admin_url %}<a href="{{ model.admin_url }}" class="btn-manage">목록</a>{% endif %}
+                  {% if model.add_url %}<a href="{{ model.add_url }}" class="btn-add">추가</a>{% endif %}
+                </div>
+              </div>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+
+  <!-- ── ② 롤플레잉 관리 ── -->
+  <div class="dash-section">
+    <div class="dash-section-title">
+      <svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+      롤플레잉 관리
+    </div>
+    <div class="model-grid">
+      {% for app in app_list %}
+        {% if app.app_label == "rpg" %}
+          {% for model in app.models %}
+            <div class="model-card">
+              <div class="model-card-header">
+                <div class="model-card-icon {% if model.object_name == 'Lorebook' %}icon-amber{% elif model.object_name == 'Session' %}icon-pink{% elif model.object_name == 'HyperMemory' %}icon-violet{% else %}icon-gray{% endif %}">
+                  {% if model.object_name == "Lorebook" %}
+                    <svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+                  {% elif model.object_name == "Session" %}
+                    <svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                  {% elif model.object_name == "HyperMemory" %}
+                    <svg viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
+                  {% else %}
+                    <svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg>
+                  {% endif %}
+                </div>
+                {% if model.object_name == "Lorebook" %}<span class="coming-tag" style="opacity:1; background:#fffbeb; color:#d97706;">핵심</span>{% endif %}
+              </div>
+              <h4>{{ model.name }}</h4>
+              <p class="model-desc">
+                {% if model.object_name == "Lorebook" %}시나리오·세계관 프롬프트 관리{% elif model.object_name == "Session" %}진행 중인 RPG 세션 조회{% elif model.object_name == "HyperMemory" %}세션 메모리 요약 기록{% elif model.object_name == "CharacterImage" %}하리 캐릭터 이미지 관리{% else %}{{ model.name }}{% endif %}
+              </p>
+              <div class="card-actions">
+                {% if model.admin_url %}<a href="{{ model.admin_url }}" class="btn-manage">목록</a>{% endif %}
+                {% if model.add_url %}<a href="{{ model.add_url }}" class="btn-add">추가</a>{% endif %}
+              </div>
+            </div>
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+
+  <!-- ── ③ AI & 하리 설정 ── -->
+  <div class="dash-section">
+    <div class="dash-section-title">
+      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+      AI &amp; 하리 설정
+    </div>
+    <div class="model-grid">
+      {% for app in app_list %}
+        {% if app.app_label == "chat" %}
+          {% for model in app.models %}
+            {% if model.object_name == "HariKnowledge" or model.object_name == "UserPersona" %}
+              <div class="model-card">
+                <div class="model-card-header">
+                  <div class="model-card-icon {% if model.object_name == 'HariKnowledge' %}icon-amber{% else %}icon-blue{% endif %}">
+                    {% if model.object_name == "HariKnowledge" %}
+                      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                    {% else %}
+                      <svg viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                    {% endif %}
+                  </div>
+                  {% if model.object_name == "HariKnowledge" %}<span class="coming-tag" style="opacity:1; background:#fffbeb; color:#d97706;">핵심</span>{% endif %}
+                </div>
+                <h4>{{ model.name }}</h4>
+                <p class="model-desc">
+                  {% if model.object_name == "HariKnowledge" %}하리 페르소나·지식 벡터 관리{% else %}유저별 페르소나 메모리 기록{% endif %}
+                </p>
+                <div class="card-actions">
+                  {% if model.admin_url %}<a href="{{ model.admin_url }}" class="btn-manage">목록</a>{% endif %}
+                  {% if model.add_url %}<a href="{{ model.add_url }}" class="btn-add">추가</a>{% endif %}
+                </div>
+              </div>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+
+  <!-- ── ④ 채팅 모니터링 ── -->
+  <div class="dash-section">
+    <div class="dash-section-title">
+      <svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+      채팅 모니터링
+    </div>
+    <div class="model-grid">
+      {% for app in app_list %}
+        {% if app.app_label == "chat" %}
+          {% for model in app.models %}
+            {% if model.object_name == "Message" or model.object_name == "ChatMemory" %}
+              <div class="model-card">
+                <div class="model-card-header">
+                  <div class="model-card-icon {% if model.object_name == 'Message' %}icon-pink{% else %}icon-violet{% endif %}">
+                    {% if model.object_name == "Message" %}
+                      <svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                    {% else %}
+                      <svg viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg>
+                    {% endif %}
+                  </div>
+                </div>
+                <h4>{{ model.name }}</h4>
+                <p class="model-desc">
+                  {% if model.object_name == "Message" %}유저↔하리 채팅 메시지 로그{% else %}세션 메모리 요약 기록{% endif %}
+                </p>
+                <div class="card-actions">
+                  {% if model.admin_url %}<a href="{{ model.admin_url }}" class="btn-manage">목록</a>{% endif %}
+                  {% if model.add_url %}<a href="{{ model.add_url }}" class="btn-add">추가</a>{% endif %}
+                </div>
+              </div>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+
+  <!-- ── ⑤ 콘텐츠 관리 ── -->
+  <div class="dash-section">
+    <div class="dash-section-title">
+      <svg viewBox="0 0 24 24"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>
+      콘텐츠 관리
+    </div>
+    <div class="model-grid">
+      {% for app in app_list %}
+        {% if app.app_label == "chat" %}
+          {% for model in app.models %}
+            {% if model.object_name == "GeneratedContent" or model.object_name == "VisitLog" %}
+              <div class="model-card">
+                <div class="model-card-header">
+                  <div class="model-card-icon {% if model.object_name == 'GeneratedContent' %}icon-green{% else %}icon-gray{% endif %}">
+                    {% if model.object_name == "GeneratedContent" %}
+                      <svg viewBox="0 0 24 24"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>
+                    {% else %}
+                      <svg viewBox="0 0 24 24"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                    {% endif %}
+                  </div>
+                </div>
+                <h4>{{ model.name }}</h4>
+                <p class="model-desc">
+                  {% if model.object_name == "GeneratedContent" %}AI 생성 콘텐츠·발행 관리{% else %}유저 방문 기록 조회{% endif %}
+                </p>
+                <div class="card-actions">
+                  {% if model.admin_url %}<a href="{{ model.admin_url }}" class="btn-manage">목록</a>{% endif %}
+                  {% if model.add_url %}<a href="{{ model.add_url }}" class="btn-add">추가</a>{% endif %}
+                </div>
+              </div>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+
+  <!-- ── ⑥~⑨ 예정 섹션 (백엔드 협의) ── -->
+  <div class="dash-section">
+    <div class="dash-section-title">
+      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+      예정 — 백엔드 협의 필요
+    </div>
+    <div class="model-grid">
+      <div class="model-card coming-soon">
+        <div class="model-card-header">
+          <div class="model-card-icon icon-gray">
+            <svg viewBox="0 0 24 24"><rect x="1" y="4" width="22" height="16" rx="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
+          </div>
+          <span class="coming-tag">미구현</span>
+        </div>
+        <h4>멤버십 &amp; 결제</h4>
+        <p class="model-desc">구독 플랜·결제 내역 관리</p>
+        <div class="card-actions">
+          <a href="#" class="btn-disabled">백엔드 모델 필요</a>
+        </div>
+      </div>
+      <div class="model-card coming-soon">
+        <div class="model-card-header">
+          <div class="model-card-icon icon-gray">
+            <svg viewBox="0 0 24 24"><path d="M18 8h1a4 4 0 0 1 0 8h-1"/><path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z"/></svg>
+          </div>
+          <span class="coming-tag">미구현</span>
+        </div>
+        <h4>공지 &amp; 이벤트</h4>
+        <p class="model-desc">배너·이벤트·출석 보너스 관리</p>
+        <div class="card-actions">
+          <a href="#" class="btn-disabled">백엔드 모델 필요</a>
+        </div>
+      </div>
+      <div class="model-card coming-soon">
+        <div class="model-card-header">
+          <div class="model-card-icon icon-gray">
+            <svg viewBox="0 0 24 24"><path d="M9 3H5a2 2 0 0 0-2 2v4m6-6h10a2 2 0 0 1 2 2v4M9 3v18m0 0h10a2 2 0 0 0 2-2V9M9 21H5a2 2 0 0 1-2-2V9m0 0h18"/></svg>
+          </div>
+          <span class="coming-tag">미구현</span>
+        </div>
+        <h4>시스템 &amp; 로그</h4>
+        <p class="model-desc">에러 로그·헬스체크·관리자 접근 기록</p>
+        <div class="card-actions">
+          <a href="#" class="btn-disabled">백엔드 모델 필요</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div><!-- /.dash-wrap -->
 {% endblock %}

--- a/backend/templates/admin/object_history.html
+++ b/backend/templates/admin/object_history.html
@@ -1,0 +1,209 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block title %}{{ object }} 변경 내역 | HARI 관리자{% endblock %}
+
+{% block content %}
+<style>
+  .history-wrap { max-width: 860px; }
+
+  .history-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: 22px;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .history-header h1 {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #2a1018;
+    margin: 0 0 4px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .history-header h1 svg {
+    width: 16px; height: 16px;
+    stroke: #e05060; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .history-header p {
+    font-size: 0.76rem;
+    color: #9a7080;
+    margin: 0;
+  }
+  .history-header a.back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    border: 1px solid #f0e0e3;
+    border-radius: var(--radius);
+    font-size: 0.76rem;
+    font-weight: 500;
+    color: #7a5060 !important;
+    text-decoration: none !important;
+    background: #fff;
+    transition: background 0.13s;
+    flex-shrink: 0;
+  }
+  .history-header a.back-btn:hover { background: #fff5f6 !important; }
+
+  /* 타임라인 */
+  .history-timeline {
+    position: relative;
+  }
+  .history-timeline::before {
+    content: '';
+    position: absolute;
+    left: 17px;
+    top: 24px;
+    bottom: 24px;
+    width: 2px;
+    background: #f0e0e3;
+    border-radius: 1px;
+  }
+
+  .history-item {
+    display: flex;
+    gap: 16px;
+    padding: 14px 0;
+    position: relative;
+  }
+  .history-item + .history-item {
+    border-top: 1px solid #fdf0f2;
+  }
+
+  .history-dot {
+    width: 36px; height: 36px;
+    border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+    position: relative;
+    z-index: 1;
+  }
+  .history-dot svg {
+    width: 14px; height: 14px;
+    stroke: currentColor; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .dot-add    { background: #ecfdf5; color: #059669; }
+  .dot-change { background: #eff6ff; color: #3b82f6; }
+  .dot-delete { background: #fff5f5; color: #ef4444; }
+
+  .history-content {
+    flex: 1;
+    min-width: 0;
+    padding-top: 6px;
+  }
+  .history-content .action-msg {
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: #2a1018;
+    margin-bottom: 4px;
+    line-height: 1.4;
+  }
+  .history-content .action-meta {
+    font-size: 0.72rem;
+    color: #9a7080;
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .history-content .action-meta svg {
+    width: 11px; height: 11px;
+    stroke: currentColor; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+    opacity: 0.6;
+  }
+  .action-user {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-weight: 600;
+    color: #e05060;
+  }
+  .action-time {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  /* 빈 상태 */
+  .history-empty {
+    text-align: center;
+    padding: 48px 20px;
+    color: #c0a0aa;
+    font-size: 0.82rem;
+  }
+  .history-empty svg {
+    width: 32px; height: 32px;
+    stroke: #e0c0c8; fill: none;
+    stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round;
+    display: block;
+    margin: 0 auto 12px;
+  }
+</style>
+
+<div class="history-wrap">
+
+  <div class="history-header">
+    <div>
+      <h1>
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        변경 내역
+      </h1>
+      <p>
+        <strong>{{ object }}</strong>에 대한 관리자 액션 로그입니다.
+      </p>
+    </div>
+    <a href="../" class="back-btn">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
+      수정 페이지로 돌아가기
+    </a>
+  </div>
+
+  {% if action_list %}
+  <div class="history-timeline">
+    {% for action in action_list %}
+    <div class="history-item">
+      <!-- 타임라인 점 -->
+      <div class="history-dot
+        {% if action.is_addition %}dot-add{% elif action.is_change %}dot-change{% else %}dot-delete{% endif %}">
+        {% if action.is_addition %}
+          <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        {% elif action.is_change %}
+          <svg viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+        {% else %}
+          <svg viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>
+        {% endif %}
+      </div>
+
+      <div class="history-content">
+        <div class="action-msg">{{ action.get_change_message }}</div>
+        <div class="action-meta">
+          <span class="action-user">
+            <svg viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+            {{ action.user }}
+          </span>
+          <span class="action-time">
+            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+            {{ action.action_time }}
+          </span>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="history-empty">
+    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+    아직 변경 내역이 없습니다.
+  </div>
+  {% endif %}
+
+</div>
+{% endblock %}

--- a/backend/templates/admin/rpg/characterimage/change_form.html
+++ b/backend/templates/admin/rpg/characterimage/change_form.html
@@ -1,0 +1,272 @@
+{% extends "admin/change_form.html" %}
+
+{% block after_field_sets %}
+<style>
+  .img-preview-section {
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    border-radius: 10px;
+    padding: 18px 22px;
+    margin: 20px 0;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+  }
+  .img-preview-section h3 {
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: #2a1018;
+    margin: 0 0 14px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .img-preview-section h3 svg {
+    width: 14px; height: 14px;
+    stroke: #e05060; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+
+  .img-preview-box {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  /* 미리보기 영역 */
+  #img-preview-wrap {
+    width: 200px;
+    height: 200px;
+    border: 2px dashed #f0c0cc;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #fdf8f9;
+    overflow: hidden;
+    flex-shrink: 0;
+    position: relative;
+  }
+  #img-preview-wrap img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    display: none;
+    border-radius: 8px;
+  }
+  #img-preview-placeholder {
+    text-align: center;
+    color: #c0a0b0;
+    font-size: 0.72rem;
+    line-height: 1.5;
+  }
+  #img-preview-placeholder svg {
+    width: 28px; height: 28px;
+    stroke: #e0c0ca; fill: none;
+    stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round;
+    display: block;
+    margin: 0 auto 6px;
+  }
+
+  /* 에러 상태 */
+  #img-preview-wrap.error { border-color: #fca5a5; background: #fff5f5; }
+  #img-preview-error {
+    display: none;
+    text-align: center;
+    color: #ef4444;
+    font-size: 0.7rem;
+  }
+  #img-preview-error svg {
+    width: 24px; height: 24px;
+    stroke: #ef4444; fill: none;
+    stroke-width: 1.5;
+    display: block; margin: 0 auto 6px;
+  }
+
+  /* 미리보기 버튼 */
+  #img-preview-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 15px;
+    background: #ff7b8a;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+    margin-top: 8px;
+    transition: opacity 0.15s;
+  }
+  #img-preview-btn:hover { opacity: 0.85; }
+
+  /* 메타 정보 */
+  .img-meta {
+    background: #fdf8f9;
+    border: 1px solid #f0e0e3;
+    border-radius: 7px;
+    padding: 10px 14px;
+    font-size: 0.72rem;
+    color: #7a5060;
+    margin-top: 10px;
+    display: none;
+  }
+  .img-meta span { display: block; }
+  .img-meta strong { color: #c04060; }
+
+  /* 조합 뱃지 */
+  .combo-badges {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .combo-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 0.73rem;
+    font-weight: 600;
+  }
+  .combo-badge.clothes { background: #eff6ff; color: #2563eb; border: 1px solid #bfdbfe; }
+  .combo-badge.emotion { background: #fff0f5; color: #db2777; border: 1px solid #fbcfe8; }
+  .combo-badge.status  { background: #f0fdf4; color: #16a34a; border: 1px solid #bbf7d0; }
+
+  .combo-hint {
+    font-size: 0.7rem;
+    color: #9a7080;
+    margin-top: 6px;
+    line-height: 1.4;
+  }
+</style>
+
+<div class="img-preview-section">
+  <h3>
+    <svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg>
+    이미지 미리보기
+  </h3>
+
+  <div class="img-preview-box">
+    <div>
+      <div id="img-preview-wrap">
+        <div id="img-preview-placeholder">
+          <svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg>
+          image_url을<br>입력 후 미리보기
+        </div>
+        <img id="img-preview-el" alt="캐릭터 이미지 미리보기">
+        <div id="img-preview-error">
+          <svg viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          이미지를 불러올 수 없습니다.<br>URL을 확인하세요.
+        </div>
+      </div>
+      <button type="button" id="img-preview-btn">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+        미리보기
+      </button>
+      <div class="img-meta" id="img-meta-box">
+        <span><strong>URL:</strong> <span id="img-meta-url">—</span></span>
+      </div>
+    </div>
+
+    <div class="combo-badges">
+      <div>
+        <div class="combo-badge clothes" id="badge-clothes">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.38 3.46 16 2a4 4 0 0 1-8 0L3.62 3.46a2 2 0 0 0-1.34 2.23l.58 3.57a1 1 0 0 0 .99.84H6v10c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V10h2.15a1 1 0 0 0 .99-.84l.58-3.57a2 2 0 0 0-1.34-2.23z"/></svg>
+          <span id="badge-clothes-val">clothes: —</span>
+        </div>
+        <div class="combo-badge emotion" style="margin-top: 6px;" id="badge-emotion">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>
+          <span id="badge-emotion-val">emotion: —</span>
+        </div>
+        <div class="combo-badge status" style="margin-top: 6px;" id="badge-status">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+          <span id="badge-status-val">is_active: —</span>
+        </div>
+      </div>
+      <p class="combo-hint">
+        clothes × emotion 조합이 중복되면<br>
+        RPG 엔진은 <strong>is_active = ON</strong> 이미지를 우선 사용합니다.
+      </p>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  function getField(name) {
+    return document.querySelector('input[name="' + name + '"], select[name="' + name + '"], textarea[name="' + name + '"]');
+  }
+
+  function updateBadges() {
+    var clothesEl  = getField('clothes');
+    var emotionEl  = getField('emotion');
+    var activeEl   = getField('is_active');
+
+    if (clothesEl)  document.getElementById('badge-clothes-val').textContent  = 'clothes: '  + (clothesEl.value  || '—');
+    if (emotionEl)  document.getElementById('badge-emotion-val').textContent  = 'emotion: '  + (emotionEl.value  || '—');
+    if (activeEl) {
+      var active = activeEl.type === 'checkbox' ? (activeEl.checked ? 'ON' : 'OFF') : (activeEl.value || '—');
+      document.getElementById('badge-status-val').textContent = 'is_active: ' + active;
+    }
+  }
+
+  function loadPreview(url) {
+    var wrap        = document.getElementById('img-preview-wrap');
+    var imgEl       = document.getElementById('img-preview-el');
+    var placeholder = document.getElementById('img-preview-placeholder');
+    var errorBox    = document.getElementById('img-preview-error');
+    var metaBox     = document.getElementById('img-meta-box');
+    var metaUrl     = document.getElementById('img-meta-url');
+
+    if (!url) return;
+
+    wrap.classList.remove('error');
+    placeholder.style.display = 'none';
+    errorBox.style.display = 'none';
+    imgEl.style.display = 'none';
+
+    imgEl.onload = function () {
+      imgEl.style.display = 'block';
+      metaBox.style.display = 'block';
+      metaUrl.textContent = url.length > 60 ? url.slice(0, 57) + '…' : url;
+    };
+    imgEl.onerror = function () {
+      wrap.classList.add('error');
+      errorBox.style.display = 'block';
+      metaBox.style.display = 'none';
+    };
+    imgEl.src = url;
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var btn      = document.getElementById('img-preview-btn');
+    var urlField = getField('image_url');
+
+    // 초기 배지 갱신
+    updateBadges();
+
+    // URL 필드 변경 시 배지 갱신
+    ['clothes', 'emotion', 'is_active'].forEach(function (name) {
+      var el = getField(name);
+      if (el) el.addEventListener('change', updateBadges);
+    });
+
+    // 미리보기 버튼
+    if (btn && urlField) {
+      btn.addEventListener('click', function () {
+        var url = urlField.value.trim();
+        if (url) {
+          loadPreview(url);
+        }
+      });
+
+      // 기존 URL이 있으면 자동 미리보기
+      if (urlField.value.trim()) {
+        loadPreview(urlField.value.trim());
+      }
+    }
+  });
+})();
+</script>
+{% endblock %}

--- a/backend/templates/admin/rpg/characterimage/change_list.html
+++ b/backend/templates/admin/rpg/characterimage/change_list.html
@@ -1,0 +1,177 @@
+{% extends "admin/change_list.html" %}
+
+{% block extra_header %}
+<style>
+  .charimg-header {
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    border-radius: 10px;
+    padding: 18px 22px;
+    margin-bottom: 20px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+  }
+  .charimg-header-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-bottom: 14px;
+  }
+  .charimg-header h2 {
+    font-size: 0.86rem;
+    font-weight: 700;
+    color: #2a1018;
+    margin: 0 0 5px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .charimg-header h2 svg {
+    width: 15px; height: 15px;
+    stroke: #e05060; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .charimg-header p {
+    font-size: 0.74rem;
+    color: #9a7080;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* 매트릭스 표 */
+  .charimg-matrix {
+    background: #fdf8f9;
+    border: 1px solid #f0e0e3;
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-bottom: 14px;
+  }
+  .charimg-matrix h3 {
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    color: #c04060;
+    margin: 0 0 10px;
+  }
+  .matrix-grid {
+    display: grid;
+    grid-template-columns: auto repeat(5, 1fr);
+    gap: 4px;
+    font-size: 0.7rem;
+  }
+  .matrix-cell {
+    padding: 5px 8px;
+    border-radius: 4px;
+    text-align: center;
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    color: #7a5060;
+  }
+  .matrix-cell.header {
+    background: #fff0f1;
+    color: #c04060;
+    font-weight: 700;
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .matrix-cell.row-header {
+    background: #fff0f1;
+    color: #c04060;
+    font-weight: 700;
+    text-align: left;
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  /* 빠른 추가 */
+  .charimg-actions a {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-size: 0.76rem;
+    font-weight: 600;
+    text-decoration: none !important;
+    background: #ff7b8a;
+    color: #fff !important;
+  }
+  .charimg-actions a:hover { opacity: 0.85; }
+
+  /* URL 형식 안내 */
+  .url-guide {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    padding: 10px 14px;
+    font-size: 0.72rem;
+    color: #64748b;
+    font-family: 'Consolas', 'Monaco', monospace;
+  }
+  .url-guide strong { color: #e05060; font-family: inherit; }
+</style>
+
+<div class="charimg-header">
+  <div class="charimg-header-top">
+    <div>
+      <h2>
+        <svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg>
+        캐릭터 이미지 관리
+      </h2>
+      <p>
+        하리의 <strong>clothes × emotion</strong> 조합으로 표시할 캐릭터 이미지를 관리합니다.<br>
+        RPG 대화 중 하리의 감정·상황에 따라 자동으로 선택됩니다.
+      </p>
+    </div>
+    <div class="charimg-actions">
+      <a href="add/">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        이미지 추가
+      </a>
+    </div>
+  </div>
+
+  <div class="charimg-matrix">
+    <h3>clothes × emotion 매트릭스 (예시)</h3>
+    <div class="matrix-grid">
+      <div class="matrix-cell header">clothes ↓ / emotion →</div>
+      <div class="matrix-cell header">happy</div>
+      <div class="matrix-cell header">sad</div>
+      <div class="matrix-cell header">thinking</div>
+      <div class="matrix-cell header">angry</div>
+      <div class="matrix-cell header">neutral</div>
+
+      <div class="matrix-cell row-header">suit</div>
+      <div class="matrix-cell">✓</div>
+      <div class="matrix-cell">✓</div>
+      <div class="matrix-cell">✓</div>
+      <div class="matrix-cell">—</div>
+      <div class="matrix-cell">✓</div>
+
+      <div class="matrix-cell row-header">daily</div>
+      <div class="matrix-cell">✓</div>
+      <div class="matrix-cell">✓</div>
+      <div class="matrix-cell">—</div>
+      <div class="matrix-cell">—</div>
+      <div class="matrix-cell">✓</div>
+
+      <div class="matrix-cell row-header">casual</div>
+      <div class="matrix-cell">✓</div>
+      <div class="matrix-cell">—</div>
+      <div class="matrix-cell">✓</div>
+      <div class="matrix-cell">—</div>
+      <div class="matrix-cell">✓</div>
+    </div>
+  </div>
+
+  <div class="url-guide">
+    <strong>image_url 형식</strong>:
+    S3 경로 → <code>https://s3.amazonaws.com/[버킷]/hari/[clothes]_[emotion].png</code><br>
+    CDN 경로 → <code>https://cdn.chatting-hari.com/characters/[clothes]_[emotion].webp</code>
+  </div>
+</div>
+{% endblock %}

--- a/backend/templates/admin/rpg/hypermemory/change_list.html
+++ b/backend/templates/admin/rpg/hypermemory/change_list.html
@@ -1,0 +1,109 @@
+{% extends "admin/change_list.html" %}
+
+{% block extra_header %}
+<style>
+  .hm-header {
+    background: linear-gradient(135deg, #1e1b35 0%, #2d1545 100%);
+    border: 1px solid rgba(139,92,246,0.25);
+    border-radius: 10px;
+    padding: 18px 22px;
+    margin-bottom: 20px;
+  }
+  .hm-header h2 {
+    font-size: 0.86rem;
+    font-weight: 700;
+    color: #f8fafc;
+    margin: 0 0 6px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .hm-header h2 svg {
+    width: 15px; height: 15px;
+    stroke: #a78bfa; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .hm-header p {
+    font-size: 0.74rem;
+    color: rgba(248,250,252,0.45);
+    margin: 0 0 14px;
+    line-height: 1.5;
+  }
+
+  .hm-fields {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 14px;
+  }
+  .hm-chip {
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(139,92,246,0.2);
+    border-radius: 6px;
+    padding: 6px 11px;
+    font-size: 0.7rem;
+  }
+  .hm-chip strong { color: #c4b5fd; display: block; margin-bottom: 2px; font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.07em; }
+  .hm-chip span { color: rgba(248,250,252,0.45); }
+
+  .hm-warning {
+    background: rgba(239,68,68,0.08);
+    border: 1px solid rgba(239,68,68,0.2);
+    border-radius: 6px;
+    padding: 9px 13px;
+    font-size: 0.73rem;
+    color: rgba(255,150,150,0.8);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .hm-warning svg {
+    width: 13px; height: 13px;
+    stroke: rgba(255,100,100,0.7); fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+    flex-shrink: 0;
+  }
+</style>
+
+<div class="hm-header">
+  <h2>
+    <svg viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
+    하이퍼 메모리 (HyperMemory)
+  </h2>
+  <p>
+    RPG 엔진이 일정 토큰 누적 후 자동 생성하는 세션 요약 스냅샷입니다.<br>
+    장소·시간·등장인물·사건·대화를 구조화해서 저장하고, 이후 세션에서 장기 컨텍스트로 활용합니다.
+  </p>
+
+  <div class="hm-fields">
+    <div class="hm-chip">
+      <strong>context_overview</strong>
+      <span>스토리 요약 텍스트</span>
+    </div>
+    <div class="hm-chip">
+      <strong>location / in_game_date</strong>
+      <span>게임 내 장소·날짜</span>
+    </div>
+    <div class="hm-chip">
+      <strong>characters_present</strong>
+      <span>등장 캐릭터 JSON 배열</span>
+    </div>
+    <div class="hm-chip">
+      <strong>dialogues</strong>
+      <span>주요 대화 JSON</span>
+    </div>
+    <div class="hm-chip">
+      <strong>emotional_dynamics</strong>
+      <span>감정·관계·긴장도</span>
+    </div>
+  </div>
+
+  <div class="hm-warning">
+    <svg viewBox="0 0 24 24"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+    <span>
+      <strong>수동 편집 금지</strong> — 하이퍼 메모리는 RPG 엔진이 자동 생성합니다.
+      수동 편집 시 세션 일관성이 깨질 수 있습니다. 조회 전용으로 사용하세요.
+    </span>
+  </div>
+</div>
+{% endblock %}

--- a/backend/templates/admin/rpg/lorebook/change_list.html
+++ b/backend/templates/admin/rpg/lorebook/change_list.html
@@ -1,0 +1,137 @@
+{% extends "admin/change_list.html" %}
+{% load static %}
+
+{% block extra_header %}
+<style>
+  /* ── 로어북 정보 카드 ── */
+  .lorebook-info {
+    background: linear-gradient(135deg, #0f172a 0%, #1e1b35 100%);
+    border: 1px solid rgba(245,158,11,0.2);
+    border-radius: 10px;
+    padding: 20px 24px;
+    margin-bottom: 22px;
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+  .lorebook-info-main h2 {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: #f8fafc;
+    margin: 0 0 6px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .lorebook-info-main h2 svg {
+    width: 16px; height: 16px;
+    stroke: #f59e0b; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .lorebook-info-main p {
+    font-size: 0.76rem;
+    color: rgba(248,250,252,0.45);
+    margin: 0;
+    line-height: 1.5;
+    max-width: 440px;
+  }
+
+  .lorebook-fields {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    flex: 1;
+    min-width: 280px;
+  }
+  .lorebook-field-chip {
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 6px;
+    padding: 8px 12px;
+    min-width: 110px;
+  }
+  .lorebook-field-chip .chip-label {
+    font-size: 0.58rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(245,158,11,0.7);
+    display: block;
+    margin-bottom: 3px;
+  }
+  .lorebook-field-chip .chip-desc {
+    font-size: 0.72rem;
+    color: rgba(248,250,252,0.5);
+    line-height: 1.3;
+  }
+
+  .lorebook-actions {
+    display: flex;
+    gap: 8px;
+    margin-left: auto;
+    align-items: flex-start;
+  }
+  .lorebook-actions a {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-size: 0.76rem;
+    font-weight: 600;
+    text-decoration: none !important;
+    transition: opacity 0.14s;
+  }
+  .lorebook-actions a:hover { opacity: 0.85; }
+  .btn-new-scenario {
+    background: #f59e0b;
+    color: #0f172a !important;
+  }
+
+  /* ── 상태 뱃지 컬럼 ── */
+  .td-is-active-true  { color: #22c55e !important; font-weight: 600; }
+  .td-is-active-false { color: #ef4444 !important; }
+  .td-is-const-true   { color: #f59e0b !important; font-weight: 600; }
+</style>
+
+<div class="lorebook-info">
+  <div class="lorebook-info-main">
+    <h2>
+      <svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+      시나리오 (로어북) 관리
+    </h2>
+    <p>
+      각 로어북은 하리 RPG 채팅에 주입되는 세계관 프롬프트입니다.<br>
+      <strong style="color:rgba(245,158,11,0.8)">is_constant = ON</strong>이면 모든 대화에 항상 주입됩니다.<br>
+      keywords에 매칭된 단어가 대화에 등장할 때만 주입됩니다.
+    </p>
+  </div>
+
+  <div class="lorebook-fields">
+    <div class="lorebook-field-chip">
+      <span class="chip-label">keywords</span>
+      <span class="chip-desc">트리거 키워드 목록. 이 단어가 대화에 등장하면 주입.</span>
+    </div>
+    <div class="lorebook-field-chip">
+      <span class="chip-label">lorebook</span>
+      <span class="chip-desc">실제로 LLM에 주입되는 시나리오 프롬프트 본문.</span>
+    </div>
+    <div class="lorebook-field-chip">
+      <span class="chip-label">priority</span>
+      <span class="chip-desc">여러 로어북 동시 매칭 시 우선순위. 높을수록 먼저 처리.</span>
+    </div>
+    <div class="lorebook-field-chip">
+      <span class="chip-label">is_constant</span>
+      <span class="chip-desc">ON이면 keywords 무관하게 항상 주입.</span>
+    </div>
+  </div>
+
+  <div class="lorebook-actions">
+    <a href="add/" class="btn-new-scenario">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      새 시나리오 추가
+    </a>
+  </div>
+</div>
+{% endblock %}

--- a/backend/templates/admin/rpg/session/change_list.html
+++ b/backend/templates/admin/rpg/session/change_list.html
@@ -1,0 +1,108 @@
+{% extends "admin/change_list.html" %}
+
+{% block extra_header %}
+<style>
+  .session-header {
+    background: #fff;
+    border: 1px solid #f0e0e3;
+    border-radius: 10px;
+    padding: 18px 22px;
+    margin-bottom: 20px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+  }
+  .session-header-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-bottom: 14px;
+  }
+  .session-header h2 {
+    font-size: 0.86rem;
+    font-weight: 700;
+    color: #2a1018;
+    margin: 0 0 5px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .session-header h2 svg {
+    width: 15px; height: 15px;
+    stroke: #e05060; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .session-header p {
+    font-size: 0.74rem;
+    color: #9a7080;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* 위험 경고 */
+  .session-danger {
+    background: #fff5f5;
+    border: 1px solid #fecaca;
+    border-left: 4px solid #ef4444;
+    border-radius: 6px;
+    padding: 10px 14px;
+    font-size: 0.76rem;
+    color: #991b1b;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+  }
+  .session-danger svg {
+    width: 14px; height: 14px;
+    stroke: #ef4444; fill: none;
+    stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+    flex-shrink: 0; margin-top: 1px;
+  }
+
+  /* 필드 배지 */
+  .session-fields {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .sf-chip {
+    font-size: 0.7rem;
+    background: #fdf4f5;
+    border: 1px solid #f0e0e3;
+    border-radius: 5px;
+    padding: 4px 10px;
+    color: #7a5060;
+  }
+  .sf-chip strong { color: #c04060; }
+</style>
+
+<div class="session-header">
+  <div class="session-header-row">
+    <div>
+      <h2>
+        <svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+        RPG 세션 모니터링
+      </h2>
+      <p>
+        유저별 RPG 채팅 세션 목록입니다. 세션 하나에 연결된 ChatLog, HyperMemory, StoryProgress가 모두 포함됩니다.<br>
+        세션 삭제 시 해당 세션의 <strong>모든 채팅 기록이 함께 삭제</strong>됩니다.
+      </p>
+    </div>
+  </div>
+
+  <div class="session-fields" style="margin-bottom: 12px;">
+    <span class="sf-chip"><strong>stress</strong> 유저 스트레스 수치 (게임 내)</span>
+    <span class="sf-chip"><strong>crack_stage</strong> 세계 균열 단계 (스토리 진행도)</span>
+    <span class="sf-chip"><strong>total_tokens</strong> 누적 토큰 수 (하이퍼메모리 트리거 기준)</span>
+    <span class="sf-chip"><strong>status_window_enabled</strong> 상태창 표시 ON/OFF</span>
+  </div>
+
+  <div class="session-danger">
+    <svg viewBox="0 0 24 24"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+    <span>
+      <strong>세션 삭제 주의</strong> — 세션을 삭제하면 연결된 ChatLog, HyperMemory, MessageEmbedding 등
+      <em>모든 하위 데이터가 CASCADE 삭제</em>됩니다. 일반적으로 세션은 삭제하지 마세요.
+    </span>
+  </div>
+</div>
+{% endblock %}

--- a/backend/templates/frontend/homepage.html
+++ b/backend/templates/frontend/homepage.html
@@ -1619,11 +1619,24 @@ function doSignup(){
   const email=panel.querySelector('input[type="email"]').value;
   const pw=document.getElementById('signup-pw').value;
   const agreed=panel.querySelector('input[type="checkbox"][required]');
+
+  // 임시: 프론트엔드 입력 검증 로직 제거 (개발 편의)
+  /*
   if(!email||!pw){alert('이메일과 비밀번호를 입력해주세요.');return;}
   if(!window.emailValidated){alert('이메일 검증을 완료해주세요.');return;}
   if(!window.passwordValidated){alert('비밀번호 검증을 완료해주세요.');return;}
+  */
   if(!agreed.checked){alert('이용약관에 동의해주세요.');return;}
+
   btn.textContent='가입 중...'; btn.disabled=true;
+
+  // 임시: 백엔드 모의 동작 (api연동 전 임시 모드)
+  setTimeout(()=>{
+    alert('회원가입 완료! (현재 백엔드 연동 전이므로 로컬 테스트 모드로 넘어갑니다.)');
+    window.location.reload();
+  }, 500);
+
+  /*
   fetch('/api/auth/registration/',{
     method:'POST',
     headers:{'Content-Type':'application/json','X-CSRFToken':getCookie('csrftoken')},
@@ -1642,6 +1655,7 @@ function doSignup(){
       :'회원가입에 실패했습니다.';
     alert(msg);
   });
+  */
 }
 function doForgot(){
   const btn=document.querySelector('#panel-forgot .auth-submit');

--- a/backend/templates/frontend/includes/homepage/_nav_auth.html
+++ b/backend/templates/frontend/includes/homepage/_nav_auth.html
@@ -445,26 +445,17 @@
       <div class="auth-field">
         <label class="auth-label" for="signupEmail">이메일</label>
         <div style="position:relative; display:flex; align-items:center; gap:0.5rem;">
-          <input class="auth-inp" id="signupEmail" name="signupEmail" type="email" placeholder="hello@hari.kr" style="flex:1;" oninput="debounceEmailCheck(this.value)">
-          <span id="email-status" style="font-size:1.2rem; min-width:24px; text-align:center; flex-shrink:0;"></span>
+          <input class="auth-inp" id="signupEmail" name="signupEmail" type="email" placeholder="hello@hari.kr" style="flex:1;">
         </div>
-        <div id="email-message" style="font-size:0.75rem; margin-top:0.3rem; min-height:16px; color:#ff7b8a;"></div>
       </div>
       <div class="auth-field">
         <label class="auth-label" for="signup-pw">비밀번호</label>
         <div style="position:relative; display:flex; align-items:center; gap:0.5rem;">
           <div class="pw-wrap" style="flex:1;">
-            <input class="auth-inp" id="signup-pw" name="signup-pw" type="password" placeholder="8자 이상" oninput="checkStrength(this); debouncePasswordCheck(this.value)">
+            <input class="auth-inp" id="signup-pw" name="signup-pw" type="password" placeholder="8자 이상">
             <button class="pw-toggle" type="button" onclick="togglePw('signup-pw',this)">표시</button>
           </div>
-          <span id="password-status" style="font-size:1.2rem; min-width:24px; text-align:center; flex-shrink:0;"></span>
         </div>
-        <div class="pw-strength" id="pw-bars">
-          <div class="pw-bar" id="bar1"></div>
-          <div class="pw-bar" id="bar2"></div>
-          <div class="pw-bar" id="bar3"></div>
-        </div>
-        <div id="password-message" style="font-size:0.75rem; margin-top:0.3rem; min-height:16px; color:#ff7b8a;"></div>
       </div>
 
       <label class="auth-check" for="signup-terms">

--- a/backend/templates/frontend/signup.html
+++ b/backend/templates/frontend/signup.html
@@ -209,22 +209,17 @@ html[data-theme="dark"] .modal-head{background:#1a1612;}
       <div class="auth-field">
         <label class="auth-label" style="font-size:0.65rem !important;">이메일</label>
         <div style="position:relative; display:flex; align-items:center; gap:0.5rem;">
-          <input class="auth-inp" id="reg-email" type="email" placeholder="hello@hari.kr" autocomplete="email" style="font-size:1.05rem !important; padding:0.9rem !important; flex:1;" oninput="debounceEmailCheck(this.value)">
-          <span id="email-status" style="font-size:1.2rem; min-width:24px; text-align:center; flex-shrink:0;"></span>
+          <!-- 임시: 이메일 검증 디자인 제거 -->
+          <input class="auth-inp" id="reg-email" type="email" placeholder="hello@hari.kr" autocomplete="email" style="font-size:1.05rem !important; padding:0.9rem !important; flex:1;">
         </div>
-        <div id="email-message" style="font-size:0.75rem; margin-top:0.3rem; min-height:16px; color:#ff7b8a;"></div>
       </div>
 
       <div class="auth-field">
         <label class="auth-label" style="font-size:0.65rem !important;">비밀번호</label>
         <div class="pw-wrap">
-          <input class="auth-inp" id="reg-pw" type="password" placeholder="8자 이상" oninput="checkStrength(this)" style="font-size:1.05rem !important; padding:0.9rem !important;">
+          <!-- 임시: 비밀번호 강도 디자인 생략 -->
+          <input class="auth-inp" id="reg-pw" type="password" placeholder="8자 이상" style="font-size:1.05rem !important; padding:0.9rem !important;">
           <button class="pw-toggle" type="button" onclick="togglePw('reg-pw',this)">표시</button>
-        </div>
-        <div class="pw-strength">
-          <div class="pw-bar" id="bar1"></div>
-          <div class="pw-bar" id="bar2"></div>
-          <div class="pw-bar" id="bar3"></div>
         </div>
       </div>
 
@@ -447,6 +442,8 @@ function doSignup(){
     showError('모든 필드를 입력해주세요.');
     return;
   }
+  // 임시: 프론트엔드 검증 생략 (개발 편의)
+  /*
   if(!window.emailValidated){
     showError('이메일 검증을 완료해주세요.');
     return;
@@ -455,6 +452,7 @@ function doSignup(){
     showError('비밀번호는 8자 이상이어야 합니다.');
     return;
   }
+  */
   if(!agree){
     showError('이용약관에 동의해주세요.');
     return;
@@ -463,6 +461,13 @@ function doSignup(){
   btn.textContent = '가입 중...';
   btn.disabled = true;
 
+  // 임시: 백엔드 API 호출 생략하고 바로 가입 성공 처리 (개발 편의)
+  setTimeout(() => {
+    alert('회원가입 완료! (현재 백엔드 연동 전이므로 테스트 모드로 넘어갑니다.)');
+    window.location.href = '{% url "login_page" %}';
+  }, 500);
+
+  /*
   fetch('/api/auth/registration/', {
     method: 'POST',
     headers: {
@@ -495,6 +500,7 @@ function doSignup(){
     else if(err.non_field_errors) msg = err.non_field_errors[0];
     showError(msg);
   });
+  */
 }
 
 // 이메일 검증 전역 상태
@@ -524,6 +530,13 @@ function debounceEmailCheck(email){
 function checkEmailValidity(email){
   const statusEl = document.getElementById('email-status');
   const messageEl = document.getElementById('email-message');
+
+  // 임시: 백엔드 연결 전이므로 이메일 검증 강제 통과 (개발 편의)
+  statusEl.textContent = '✅';
+  messageEl.textContent = '사용 가능한 이메일입니다. (임시 우회됨)';
+  messageEl.style.color = '#06d6a0';
+  window.emailValidated = true;
+  return;
 
   // 이메일 형식 검증
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;


### PR DESCRIPTION
- base_site.html: 9섹션 다크 사이드바 + 모바일 햄버거 메뉴
- index.html: 대시보드 랜딩 (빠른접근 + 최근활동)
- change_list.html: 리스트 페이지 블록 렌더링 버그 수정
- 모델별 헤더 11종: user, lorebook, session, hypermemory, characterimage, message, hariknowledge, chatmemory, generatedcontent, userpersona, visitlog
- change_form.html: 코드에디터 스타일 + characterimage 이미지 미리보기
- delete_confirmation.html, object_history.html 신규 추가
- 단독 회원가입 및 홈페이지 모달의 이메일/비밀번호 검증 UI 요소 제거
- 백엔드 연동 전 개발 편의를 위해 프론트엔드 검증 로직 우회 적용
- 가입 버튼 클릭 시 API 호출을 생략하고 바로 가입 완료 처리되도록 수정