### PR TITLE
Fix: 푸터 RPG 링크 URL 동기화 (네비게이션 바와 일치)

### DIFF
--- a/backend/templates/frontend/includes/homepage/_s8_footer.html
+++ b/backend/templates/frontend/includes/homepage/_s8_footer.html
@@ -22,7 +22,7 @@
       <li><a href="/gallery/">Gallery</a></li>
       <li><a href="/video/">Videos</a></li>
       <li><a href="/hari-chat/">하리와 채팅하기</a></li>
-      <li><a href="/api/roleplay/test/">하리와 롤플레잉</a></li>
+      <li><a href="/roleplay/">하리와 롤플레잉</a></li>
       <li><a href="/membership/">Membership</a></li>
       <li><a href="#s6">Contact</a></li>
     </ul>
@@ -75,7 +75,7 @@ FOOTER_V1_END -->
   <div class="ft-engage-lbl">하리와 함께하기</div>
   <ul class="ft-engage-list">
     <li><a class="ft-chat-link" href="/hari-chat/">Chat</a></li>
-    <li><a href="/api/roleplay/test/">RPG</a></li>
+    <li><a href="/roleplay/">RPG</a></li>
     <li><a href="/membership/">Membership</a></li>
   </ul>
 </div>


### PR DESCRIPTION
- 푸터 하단 '하리와 함께하기' 섹션의 RPG URL 변경 (/roleplay/)
- 네비게이션 바 메뉴와 동일한 경로로 연결되도록 수정