### PR TITLE
Fix: 네비게이션 다크모드 토글 위치 통일 및 글씨 가독성 개선

### DIFF
--- a/BACKEND_REQUEST.md
+++ b/BACKEND_REQUEST.md
@@ -114,41 +114,6 @@ class NewsEvent(models.Model):
 
 ---
 
-#### 모델 3. `ContactSubmission` — 문의 폼 접수 저장
-
-```python
-class ContactSubmission(models.Model):
-    name         = models.CharField(max_length=100)
-    email        = models.EmailField()
-    company      = models.CharField(max_length=100, blank=True)
-    inquiry_type = models.CharField(max_length=50)
-    message      = models.TextField()
-    is_read      = models.BooleanField(default=False, help_text="관리자 확인 여부")
-    created_at   = models.DateTimeField(auto_now_add=True)
-
-    class Meta:
-        db_table  = 'contact_submission'
-        ordering  = ['-created_at']
-        verbose_name_plural = "Contact Submissions"
-
-    def __str__(self):
-        return f"{self.name} ({self.email}) - {self.inquiry_type}"
-```
-
-**왜 필요한가:** 현재 `contact_form` 뷰가 폼 데이터를 DB에 저장하지 않아
-어떤 문의가 왔는지 admin에서 확인 불가. 이 모델과 함께 `views.py`의
-`contact_form` 함수에 `ContactSubmission.objects.create(...)` 한 줄 추가 필요.
-
-**추가 요청 (views.py):**
-```python
-# chat/views.py contact_form 함수 안에 추가
-ContactSubmission.objects.create(
-    name=name, email=email,
-    company=company, inquiry_type=inquiry_type, message=message
-)
-```
-
----
 
 #### 모델 4. `VideoContent` — YouTube 비디오 관리
 

--- a/backend/templates/frontend/abouthari.html
+++ b/backend/templates/frontend/abouthari.html
@@ -43,6 +43,9 @@ body{background:var(--bg);color:var(--ink);font-family:Pretendard,'Apple SD Goth
 .pf-nav-back svg{transition:transform .2s;}
 .pf-nav-back:hover svg{transform:translateX(-3px);}
 
+/* NAV RIGHT GROUP */
+.pf-nav-right{display:flex;align-items:center;gap:1.2rem;}
+
 /* THEME TOGGLE */
 .pf-theme-wrap{display:flex;align-items:center;gap:.4rem;flex-shrink:0;}
 #theme-toggle{position:relative;width:44px;height:26px;background:#ddd;border:none;border-radius:20px;cursor:pointer;transition:background .3s ease,box-shadow .2s ease;display:flex;align-items:center;padding:0 2px;box-shadow:inset 0 1px 3px rgba(0,0,0,0.1);flex-shrink:0;}
@@ -85,22 +88,22 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
 .pf-stat{padding:1.2rem 1rem;border-right:.5px solid var(--bdr);text-align:center;}
 .pf-stat:last-child{border-right:none;}
 .pf-stat-num{font-family:'Bebas Neue',sans-serif;font-size:2rem;color:var(--ink);display:block;line-height:1;}
-.pf-stat-lbl{font-family:'DM Mono',monospace;font-size:.48rem;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);display:block;margin-top:.3rem;}
+.pf-stat-lbl{font-family:'DM Mono',monospace;font-size:.72rem;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);display:block;margin-top:.3rem;}
 
 /* Keywords */
 .pf-keywords{display:flex;flex-wrap:wrap;gap:.5rem;margin-bottom:2.5rem;padding-bottom:2.5rem;border-bottom:.5px solid var(--bdr);}
-.pf-kw{font-family:'DM Mono',monospace;font-size:.6rem;letter-spacing:.1em;padding:5px 14px;border:.5px solid var(--bdr2);color:var(--dim);transition:all .2s;}
+.pf-kw{font-family:'DM Mono',monospace;font-size:.82rem;letter-spacing:.1em;padding:5px 14px;border:.5px solid var(--bdr2);color:var(--dim);transition:all .2s;}
 .pf-kw:hover{border-color:var(--acc);color:var(--acc);}
 
 /* SNS */
-.pf-sns-title{font-family:'DM Mono',monospace;font-size:.54rem;letter-spacing:.2em;text-transform:uppercase;color:var(--dim);margin-bottom:1.2rem;}
+.pf-sns-title{font-family:'DM Mono',monospace;font-size:.78rem;letter-spacing:.2em;text-transform:uppercase;color:var(--dim);margin-bottom:1.2rem;}
 .pf-sns-grid{display:flex;flex-direction:column;gap:.5rem;margin-bottom:2.5rem;padding-bottom:2.5rem;border-bottom:.5px solid var(--bdr);}
 .pf-sns-item{display:flex;align-items:center;justify-content:space-between;padding:.85rem 1rem;border:.5px solid var(--bdr);text-decoration:none;transition:all .2s;}
 .pf-sns-item:hover{border-color:var(--acc);background:rgba(255,123,138,0.04);}
 .pf-sns-left{display:flex;align-items:center;gap:.9rem;}
 .pf-sns-icon{width:32px;height:32px;border-radius:8px;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
 .pf-sns-name{font-family:var(--f-playful);font-size:.95rem;color:var(--ink);}
-.pf-sns-handle{font-family:'DM Mono',monospace;font-size:.55rem;letter-spacing:.1em;color:var(--dim);}
+.pf-sns-handle{font-family:'DM Mono',monospace;font-size:.78rem;letter-spacing:.1em;color:var(--dim);}
 .pf-sns-arr{font-family:'DM Mono',monospace;font-size:.65rem;color:var(--dim);transition:transform .2s;}
 .pf-sns-item:hover .pf-sns-arr{transform:translateX(4px);color:var(--acc);}
 
@@ -116,7 +119,7 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
 /* QUOTE */
 .pf-quote{margin-bottom:2rem;padding:1.4rem 1.6rem;background:rgba(255,123,138,0.04);border-left:3px solid var(--acc);border-radius:0 10px 10px 0;}
 .pf-quote-text{font-family:var(--f-playful);font-size:1.05rem;color:var(--ink);line-height:1.8;letter-spacing:-0.01em;margin-bottom:.4rem;}
-.pf-quote-from{font-family:'DM Mono',monospace;font-size:.5rem;letter-spacing:.16em;text-transform:uppercase;color:var(--dim);}
+.pf-quote-from{font-family:'DM Mono',monospace;font-size:.72rem;letter-spacing:.16em;text-transform:uppercase;color:var(--dim);}
 
 /* LIKES */
 .pf-likes{display:grid;grid-template-columns:1fr 1fr;gap:.5rem;margin-bottom:2rem;padding-bottom:2rem;border-bottom:.5px solid var(--bdr);}
@@ -163,15 +166,17 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
   <a class="pf-nav-logo" href="/">
     <img src="{% static 'images/hari_logo_none.png' %}?v=2" alt="HARI">
   </a>
-  <div class="pf-theme-wrap">
-    <span class="pf-theme-ico">☀️</span>
-    <button id="theme-toggle" class="off" onclick="toggleTheme()" aria-label="다크 모드 전환" title="다크/라이트 모드 전환"></button>
-    <span class="pf-theme-ico">🌙</span>
+  <div class="pf-nav-right">
+    <div class="pf-theme-wrap">
+      <span class="pf-theme-ico">☀️</span>
+      <button id="theme-toggle" class="off" onclick="toggleTheme()" aria-label="다크 모드 전환" title="다크/라이트 모드 전환"></button>
+      <span class="pf-theme-ico">🌙</span>
+    </div>
+    <a class="pf-nav-back" href="/">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+      홈으로
+    </a>
   </div>
-  <a class="pf-nav-back" href="/">
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
-    홈으로
-  </a>
 </nav>
 
 <!-- MAIN -->
@@ -226,7 +231,7 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
     </div>
 
     <!-- 좋아하는 것 -->
-    <div class="pf-section-label" style="font-family:'DM Mono',monospace;font-size:.52rem;letter-spacing:.22em;text-transform:uppercase;color:var(--dim);margin-bottom:1rem;padding-bottom:.6rem;border-bottom:.5px solid var(--bdr);">하리가 좋아하는 것들</div>
+    <div class="pf-section-label" style="font-family:'DM Mono',monospace;font-size:.78rem;letter-spacing:.22em;text-transform:uppercase;color:var(--dim);margin-bottom:1rem;padding-bottom:.6rem;border-bottom:.5px solid var(--bdr);">하리가 좋아하는 것들</div>
     <div class="pf-likes">
       <div class="pf-like-item"><span class="pf-like-icon">📊</span><span class="pf-like-text">트렌드 분석</span></div>
       <div class="pf-like-item"><span class="pf-like-icon">💬</span><span class="pf-like-text">실시간 소통</span></div>

--- a/backend/templates/frontend/includes/homepage/_nav_auth.html
+++ b/backend/templates/frontend/includes/homepage/_nav_auth.html
@@ -254,11 +254,11 @@
       <!-- 06. 하리와 롤플레잉 -->
       {% if user.is_authenticated %}
       <a href="/roleplay/" class="nav-gnb-item nav-gnb-roleplay">
-        하리와 롤플레잉
+        🎭 하리와 롤플레잉
       </a>
       {% else %}
       <a href="#" onclick="openAuth('login'); return false;" class="nav-gnb-item nav-gnb-roleplay">
-        하리와 롤플레잉
+        🎭 하리와 롤플레잉
       </a>
       {% endif %}
 

--- a/backend/templates/frontend/includes/mypage/_abouthari.html
+++ b/backend/templates/frontend/includes/mypage/_abouthari.html
@@ -103,9 +103,9 @@
 
       <!-- 계정 관리 카드 -->
       <div class="card">
-        <div class="c-title">계정 관리</div>
+        <div class="c-title">위험 구역</div>
         <div class="danger-zone" style="border-radius:10px;">
-          <div class="dz-title">위험 구역</div>
+          <div class="dz-title">계정 관리</div>
           <div style="display:flex;gap:.6rem;flex-wrap:wrap">
             <button class="dz-btn" onclick="window.location.href='/api/chat/logout/'">로그아웃</button>
             <button class="dz-btn" onclick="toast('계정 탈퇴는 고객센터에 문의해주세요')">회원 탈퇴</button>

--- a/backend/templates/frontend/includes/mypage/_myinfo.html
+++ b/backend/templates/frontend/includes/mypage/_myinfo.html
@@ -74,9 +74,9 @@
 
       <!-- 계정 관리 -->
       <div class="card">
-        <div class="c-title">계정 관리</div>
+        <div class="c-title">위험 구역</div>
         <div class="danger-zone" style="border-radius:10px;">
-          <div class="dz-title">위험 구역</div>
+          <div class="dz-title">계정 관리</div>
           <div style="display:flex;gap:.6rem;flex-wrap:wrap">
             <button class="dz-btn" onclick="window.location.href='/api/chat/logout/'">로그아웃</button>
             <button class="dz-btn" onclick="toast('계정 탈퇴는 고객센터에 문의해주세요')">회원 탈퇴</button>

--- a/backend/templates/frontend/includes/mypage/_topbar.html
+++ b/backend/templates/frontend/includes/mypage/_topbar.html
@@ -4,14 +4,14 @@
   <div class="tb-left">
     <button id="sb-toggle-btn" onclick="document.getElementById('sidebar').classList.toggle('open')" style="display:none; background:transparent; border:none; font-size:1.4rem; color:var(--ink); cursor:pointer;">☰</button>
     <img src="{% static 'images/bori_logo_none.png' %}?v=2" alt="Bori" style="height:42px; width:auto; object-fit:contain; cursor: pointer; filter: contrast(110%) brightness(110%); mix-blend-mode: multiply; transition: all 0.3s ease;" onclick="location.reload()" onmouseover="this.style.transform='scale(1.05)'; this.style.opacity='0.8';" onmouseout="this.style.transform='scale(1)'; this.style.opacity='1';">
+  </div>
+  <div class="tb-center"></div>
+  <div class="tb-right">
     <div class="tb-theme-wrap">
       <span class="tb-theme-ico">☀️</span>
       <button id="theme-toggle" class="off" onclick="toggleTheme()" aria-label="다크 모드 전환" title="다크/라이트 모드 전환"></button>
       <span class="tb-theme-ico">🌙</span>
     </div>
-  </div>
-  <div class="tb-center"></div>
-  <div class="tb-right">
     <a class="tb-home" href="/">← 메인으로</a>
   </div>
 </header>

--- a/backend/templates/frontend/mypage.html
+++ b/backend/templates/frontend/mypage.html
@@ -73,14 +73,14 @@ button{cursor:pointer;font-family:inherit;}
 .tb-pts-box{display:flex;align-items:center;gap:.45rem;padding:5px 14px;border:0.5px solid var(--bdr2);background:var(--bg2);border-radius:20px;}
 .tb-pts-ico{font-size:.75rem;}
 .tb-pts-num{font-family:'NeoDunggeunmo',sans-serif;font-size:1rem;letter-spacing:.05em;color:var(--acc);}
-.tb-pts-lbl{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.48rem;letter-spacing:.12em;text-transform:uppercase;color:var(--dim);}
+.tb-pts-lbl{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.62rem;letter-spacing:.12em;text-transform:uppercase;color:var(--dim);}
 .tb-icon-btn{width:32px;height:32px;background:transparent;border:0.5px solid var(--bdr2);display:flex;align-items:center;justify-content:center;transition:border-color .2s;}
 .tb-icon-btn:hover{border-color:var(--acc);}
 .tb-icon-btn svg{width:14px;height:14px;stroke:var(--dim);fill:none;stroke-width:1.5;}
 .tb-notif-dot{width:6px;height:6px;border-radius:50%;background:var(--acc);display:block;margin-left:-8px;margin-top:-14px;border:1.5px solid var(--bg);}
 .tb-av{width:34px;height:34px;border-radius:50%;background:linear-gradient(135deg,var(--acc),#ffb3be);border:2px solid #fff;box-shadow:0 2px 8px rgba(255,123,138,0.3);display:flex;align-items:center;justify-content:center;font-family:'NeoDunggeunmo',sans-serif;font-size:.9rem;color:#fff;cursor:pointer;transition:box-shadow .2s;}
 .tb-av:hover{box-shadow:0 3px 12px rgba(255,123,138,0.45);}
-.tb-home{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.56rem;letter-spacing:.12em;text-transform:uppercase;color:var(--dim);border-bottom:0.5px solid var(--bdr2);padding-bottom:1px;transition:color .2s,border-color .2s;}
+.tb-home{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.75rem;letter-spacing:.12em;text-transform:uppercase;color:var(--dim);border-bottom:0.5px solid var(--bdr2);padding-bottom:1px;transition:color .2s,border-color .2s;}
 .tb-home:hover{color:var(--ink);border-color:var(--ink);}
 
 /* THEME TOGGLE */
@@ -103,33 +103,33 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
 
 /* SIDEBAR */
 #sidebar{width:var(--sw);flex-shrink:0;border-right:0.5px solid var(--bdr);background:var(--bg2);display:flex;flex-direction:column;overflow-y:auto;padding:1.2rem 0 1.5rem;}
-.sb-lbl{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.49rem;letter-spacing:.22em;text-transform:uppercase;color:var(--dim);padding:.35rem 1.4rem;margin-bottom:.2rem;}
+.sb-lbl{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.65rem;letter-spacing:.22em;text-transform:uppercase;color:var(--dim);padding:.35rem 1.4rem;margin-bottom:.2rem;}
 .sb-nav{list-style:none;margin-bottom:.8rem;}
-.sb-link{display:flex;align-items:center;gap:.75rem;padding:.62rem 1.4rem;font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.61rem;letter-spacing:.12em;text-transform:uppercase;color:var(--dim);border-left:2px solid transparent;transition:color .2s,background .2s,border-color .2s;}
+.sb-link{display:flex;align-items:center;gap:.75rem;padding:.62rem 1.4rem;font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.78rem;letter-spacing:.12em;text-transform:uppercase;color:var(--dim);border-left:2px solid transparent;transition:color .2s,background .2s,border-color .2s;}
 .sb-link:hover{color:var(--acc);background:rgba(255,123,138,0.06);}
 .sb-link.on{color:var(--acc);background:rgba(255,123,138,0.08);border-left-color:var(--acc);font-weight:400;}
 .sb-link svg{width:13px;height:13px;stroke:currentColor;fill:none;stroke-width:1.4;flex-shrink:0;}
-.sb-badge{margin-left:auto;font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.46rem;letter-spacing:.08em;text-transform:uppercase;background:var(--acc);color:#fff;padding:2px 8px;border-radius:20px;}
+.sb-badge{margin-left:auto;font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.62rem;letter-spacing:.08em;text-transform:uppercase;background:var(--acc);color:#fff;padding:2px 8px;border-radius:20px;}
 .sb-badge.g{background:var(--gold);}
 .sb-hr{height:0.5px;background:var(--bdr);margin:.7rem 1.4rem;}
 .sb-tier{margin:.2rem 1rem 1rem;padding:.9rem 1rem;border:0.5px solid var(--bdr2);background:var(--bg);border-radius:12px;box-shadow:0 2px 12px rgba(255,123,138,0.08);}
 .sb-tier-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:.5rem;}
-.sb-tier-name{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.57rem;letter-spacing:.12em;text-transform:uppercase;color:var(--ink);}
-.sb-tier-tag{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.48rem;letter-spacing:.1em;text-transform:uppercase;padding:2px 7px;border:0.5px solid var(--gold);color:var(--acc);}
+.sb-tier-name{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.72rem;letter-spacing:.12em;text-transform:uppercase;color:var(--ink);}
+.sb-tier-tag{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.64rem;letter-spacing:.1em;text-transform:uppercase;padding:2px 7px;border:0.5px solid var(--gold);color:var(--acc);}
 .sb-xp-bg{background:rgba(255,123,138,0.15);height:4px;margin-bottom:.35rem;border-radius:2px;overflow:hidden;}
 .sb-xp-fill{height:100%;background:linear-gradient(90deg,var(--acc),#ffb3be);transition:width .9s ease;border-radius:2px;}
-.sb-xp-txt{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.49rem;letter-spacing:.07em;color:var(--dim);}
+.sb-xp-txt{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.65rem;letter-spacing:.07em;color:var(--dim);}
 
 /* MAIN */
 #main{flex:1;overflow-y:auto;background:#fdfaf8;}
 .pg{display:none;padding:2rem 2.2rem;min-height:100%;}
 .pg.on{display:block;}
 .pg-title{font-family:var(--f-cute), sans-serif;font-size:2.4rem;letter-spacing:.04em;color:var(--ink);margin-bottom:.25rem;}
-.pg-sub{font-size:.82rem;color:var(--dim);margin-bottom:1.8rem;}
+.pg-sub{font-size:1rem;color:var(--dim);margin-bottom:1.8rem;}
 
 /* CARD */
 .card{background:var(--bg);border:0.5px solid var(--bdr);padding:1.4rem;margin-bottom:1rem;border-radius:16px;box-shadow:0 2px 16px rgba(255,123,138,0.06);}
-.c-title{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.55rem;letter-spacing:.2em;text-transform:uppercase;color:var(--acc);margin-bottom:1.1rem;display:flex;align-items:center;gap:.6rem;}
+.c-title{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.75rem;letter-spacing:.2em;text-transform:uppercase;color:var(--acc);margin-bottom:1.1rem;display:flex;align-items:center;gap:.6rem;}
 .c-title::after{content:'';flex:1;height:.5px;background:var(--bdr);}
 
 /* STAT GRID */
@@ -137,7 +137,7 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
 .sbox{background:var(--bg);padding:1.1rem 1.3rem;border-radius:14px;box-shadow:0 2px 12px rgba(255,123,138,0.06);border:0.5px solid var(--bdr);}
 .sn{font-family:'NeoDunggeunmo',sans-serif;font-size:1.9rem;letter-spacing:.04em;color:var(--ink);display:block;line-height:1;font-feature-settings:'tnum';}
 .sn.g{color:var(--acc);} .sn.gr{color:var(--grn);}
-.sl{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.5rem;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);display:block;margin-top:.2rem;}
+.sl{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.68rem;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);display:block;margin-top:.2rem;}
 
 /* GRID LAYOUTS */
 .g2{display:grid;grid-template-columns:1fr 1fr;gap:1rem;}
@@ -145,18 +145,18 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
 
 /* ACTIVITY LIST */
 .act-list{list-style:none;}
-.act-item{display:flex;align-items:center;gap:.85rem;padding:.72rem 0;border-bottom:0.5px solid var(--bdr);font-size:.82rem;}
+.act-item{display:flex;align-items:center;gap:.85rem;padding:.72rem 0;border-bottom:0.5px solid var(--bdr);font-size:1rem;}
 .act-ico{width:32px;height:32px;background:rgba(255,123,138,0.08);border-radius:50%;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
 .act-ico svg{width:13px;height:13px;stroke:var(--acc);fill:none;stroke-width:1.4;}
 .act-txt{flex:1;color:var(--ink);line-height:1.4;}
-.act-txt small{display:block;font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.5rem;letter-spacing:.07em;color:var(--dim);margin-top:1px;}
+.act-txt small{display:block;font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.68rem;letter-spacing:.07em;color:var(--dim);margin-top:1px;}
 .act-pt{font-family:'NeoDunggeunmo',sans-serif;font-size:.95rem;letter-spacing:.04em;color:var(--acc);flex-shrink:0;}
 .act-pt.m{color:#c84a3a;}
 
 /* FIELD */
 .field{display:flex;flex-direction:column;gap:.28rem;margin-bottom:.85rem;}
-.field label{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.52rem;letter-spacing:.16em;text-transform:uppercase;color:var(--dim);}
-.field input,.field select,.field textarea{background:var(--bg2);border:0.5px solid var(--bdr2);color:var(--ink);font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.84rem;padding:.62rem .85rem;outline:none;transition:border-color .2s;}
+.field label{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.7rem;letter-spacing:.16em;text-transform:uppercase;color:var(--dim);}
+.field input,.field select,.field textarea{background:var(--bg2);border:0.5px solid var(--bdr2);color:var(--ink);font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:1rem;padding:.62rem .85rem;outline:none;transition:border-color .2s;}
 .field input::placeholder,.field textarea::placeholder{color:var(--dim);}
 .field input:focus,.field select:focus,.field textarea:focus{border-color:var(--acc);background:var(--bg);}
 .field select{appearance:none;cursor:pointer;}
@@ -164,7 +164,7 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
 .frow{display:grid;grid-template-columns:1fr 1fr;gap:.75rem;}
 
 /* SAVE BTN */
-.save-btn{background:linear-gradient(135deg,var(--acc),#ff9aaa);border:none;color:#fff;font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.63rem;letter-spacing:.18em;text-transform:uppercase;padding:.72rem 2rem;transition:all .2s;border-radius:25px;box-shadow:0 4px 15px rgba(255,123,138,0.3);}
+.save-btn{background:linear-gradient(135deg,var(--acc),#ff9aaa);border:none;color:#fff;font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.8rem;letter-spacing:.18em;text-transform:uppercase;padding:.72rem 2rem;transition:all .2s;border-radius:25px;box-shadow:0 4px 15px rgba(255,123,138,0.3);}
 .save-btn:hover{transform:translateY(-1px);box-shadow:0 6px 20px rgba(255,123,138,0.4);}
 .save-btn:active{transform:scale(.97);}
 
@@ -174,43 +174,43 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
 .p-av-edit{position:absolute;bottom:0;right:0;width:24px;height:24px;border-radius:50%;background:var(--ink);border:2px solid var(--bg);display:flex;align-items:center;justify-content:center;}
 .p-av-edit svg{width:13px;height:13px;stroke:#fff;fill:none;stroke-width:2;}
 .p-name{font-family:var(--f-cute), sans-serif;font-size:1.5rem;letter-spacing:.05em;color:var(--ink);line-height:1;margin-bottom:.25rem;}
-.p-handle{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.58rem;letter-spacing:.1em;color:var(--dim);margin-bottom:.5rem;}
+.p-handle{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.76rem;letter-spacing:.1em;color:var(--dim);margin-bottom:.5rem;}
 .p-badges{display:flex;gap:.35rem;flex-wrap:wrap;}
-.pbadge{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.49rem;letter-spacing:.1em;text-transform:uppercase;padding:3px 10px;border:0.5px solid;border-radius:20px;}
+.pbadge{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.66rem;letter-spacing:.1em;text-transform:uppercase;padding:3px 10px;border:0.5px solid;border-radius:20px;}
 .pbadge.fan{color:var(--acc);border-color:rgba(122,106,82,.3);background:rgba(122,106,82,.07);}
 .pbadge.rank{color:var(--acc);border-color:rgba(201,151,26,.3);background:rgba(201,151,26,.07);}
 .pbadge.new{color:var(--grn);border-color:rgba(46,139,82,.3);background:rgba(46,139,82,.07);}
-.p-edit{background:transparent;border:0.5px solid var(--bdr2);font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.56rem;letter-spacing:.12em;text-transform:uppercase;color:var(--dim);padding:6px 13px;transition:all .2s;align-self:flex-start;}
+.p-edit{background:transparent;border:0.5px solid var(--bdr2);font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.74rem;letter-spacing:.12em;text-transform:uppercase;color:var(--dim);padding:6px 13px;transition:all .2s;align-self:flex-start;}
 .p-edit:hover{border-color:var(--ink);color:var(--ink);}
 
 
 /* MY INFO */
 .info-grid{display:grid;grid-template-columns:1fr 1fr;gap:.5rem;background:transparent;margin-bottom:1rem;}
 .info-item{background:var(--bg);padding:.9rem 1.1rem;border-radius:10px;border:0.5px solid var(--bdr);}
-.info-lbl{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.52rem;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);display:block;margin-bottom:.25rem;}
-.info-val{font-size:.85rem;color:var(--ink);}
-.info-val-input{font-size:.85rem;color:var(--ink);background:transparent;border:none;border-bottom:0.5px solid var(--bdr2);outline:none;width:100%;padding:0;font-family:inherit;transition:border-color .2s;}
+.info-lbl{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.7rem;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);display:block;margin-bottom:.25rem;}
+.info-val{font-size:1rem;color:var(--ink);}
+.info-val-input{font-size:1rem;color:var(--ink);background:transparent;border:none;border-bottom:0.5px solid var(--bdr2);outline:none;width:100%;padding:0;font-family:inherit;transition:border-color .2s;}
 .info-val-input:focus{border-bottom-color:var(--acc);}
 .info-val-input::placeholder{color:var(--dim);}
 .danger-zone{border:0.5px solid rgba(200,74,58,.25);padding:1.1rem 1.3rem;}
-.dz-title{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.54rem;letter-spacing:.16em;text-transform:uppercase;color:#c84a3a;margin-bottom:.7rem;}
-.dz-btn{background:transparent;border:0.5px solid rgba(200,74,58,.4);color:#c84a3a;font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.58rem;letter-spacing:.12em;text-transform:uppercase;padding:6px 14px;transition:all .2s;border-radius:20px;}
+.dz-title{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.72rem;letter-spacing:.16em;text-transform:uppercase;color:#c84a3a;margin-bottom:.7rem;}
+.dz-btn{background:transparent;border:0.5px solid rgba(200,74,58,.4);color:#c84a3a;font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.76rem;letter-spacing:.12em;text-transform:uppercase;padding:6px 14px;transition:all .2s;border-radius:20px;}
 .dz-btn:hover{background:rgba(200,74,58,.08);border-color:#c84a3a;}
 .notif-toggle{display:flex;align-items:center;gap:.8rem;padding:.68rem 0;border-bottom:0.5px solid var(--bdr);}
 .nt-ico{width:26px;height:26px;border:0.5px solid var(--bdr2);display:flex;align-items:center;justify-content:center;flex-shrink:0;}
 .nt-ico svg{width:12px;height:12px;stroke:var(--dim);fill:none;stroke-width:1.4;}
 .nt-text{flex:1;}
-.nt-name{font-size:.82rem;color:var(--ink);}
-.nt-desc{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.5rem;letter-spacing:.07em;color:var(--dim);}
+.nt-name{font-size:1rem;color:var(--ink);}
+.nt-desc{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.68rem;letter-spacing:.07em;color:var(--dim);}
 .nt-toggle input{accent-color:var(--acc);width:16px;height:16px;cursor:pointer;}
 
 /* REWARD CARD */
 .reward-card{padding:1rem;border:0.5px solid var(--bdr);text-align:center;border-radius:14px;background:var(--bg);}
 .reward-n{font-family:'NeoDunggeunmo',sans-serif;font-size:1.35rem;color:var(--acc);margin-bottom:.25rem;}
-.reward-d{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.52rem;letter-spacing:.1em;text-transform:uppercase;color:var(--dim);line-height:1.5;}
+.reward-d{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;color:var(--dim);line-height:1.5;}
 
 /* TOAST */
-#toast{position:fixed;bottom:2rem;left:50%;transform:translateX(-50%) translateY(80px);background:var(--ink);color:#fff;font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.62rem;letter-spacing:.1em;padding:.68rem 1.5rem;opacity:0;transition:all .3s;z-index:600;pointer-events:none;white-space:nowrap;border-radius:25px;box-shadow:0 4px 20px rgba(42,36,32,0.25);}
+#toast{position:fixed;bottom:2rem;left:50%;transform:translateX(-50%) translateY(80px);background:var(--ink);color:#fff;font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.8rem;letter-spacing:.1em;padding:.68rem 1.5rem;opacity:0;transition:all .3s;z-index:600;pointer-events:none;white-space:nowrap;border-radius:25px;box-shadow:0 4px 20px rgba(42,36,32,0.25);}
 #toast.on{opacity:1;transform:translateX(-50%) translateY(0);}
 
 /* CONTAINER QUERIES — #main 기준 */

--- a/backend/templates/frontend/video.html
+++ b/backend/templates/frontend/video.html
@@ -46,7 +46,7 @@ body{background:var(--bg);color:var(--ink);font-family:Pretendard,'Apple SD Goth
   transition:background .3s;
 }
 .vd-nav-logo img{height:44px;width:auto;mix-blend-mode:multiply;display:block;}
-.vd-nav-right{display:flex;align-items:center;}
+.vd-nav-right{display:flex;align-items:center;gap:1.2rem;}
 .vd-nav-back{
   font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;
   font-size:1.1rem;font-weight:500;letter-spacing:-0.02em;
@@ -312,15 +312,17 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
   <a class="vd-nav-logo" href="/">
     <img src="{% static 'images/hari_logo_none.png' %}?v=2" alt="HARI">
   </a>
-  <div class="vd-theme-wrap">
-    <span class="vd-theme-ico">☀️</span>
-    <button id="theme-toggle" class="off" onclick="toggleTheme()" aria-label="다크 모드 전환" title="다크/라이트 모드 전환"></button>
-    <span class="vd-theme-ico">🌙</span>
+  <div class="vd-nav-right">
+    <div class="vd-theme-wrap">
+      <span class="vd-theme-ico">☀️</span>
+      <button id="theme-toggle" class="off" onclick="toggleTheme()" aria-label="다크 모드 전환" title="다크/라이트 모드 전환"></button>
+      <span class="vd-theme-ico">🌙</span>
+    </div>
+    <a class="vd-nav-back" href="/">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+      홈으로
+    </a>
   </div>
-  <a class="vd-nav-back" href="/">
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
-    홈으로
-  </a>
 </nav>
 
 <!-- HEADER -->


### PR DESCRIPTION
- about·video 페이지: 다크모드 토글을 홈으로 버튼 왼쪽으로 이동
- 마이페이지 상단바: 다크모드 토글을 메인으로 버튼 왼쪽으로 이동
- 마이페이지 설정: 위험 구역·계정 관리 라벨 위치 교체
- 마이페이지 전체 글씨 크기 증가 (.5rem대 → .7rem대)
- 하리 소개 페이지 라벨·태그·SNS 글씨 크기 증가