### PR TITLE
Feat: 회원가입 테스트 모드 제거 및 실제 가입 저장 로직 연결

### DIFF
--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -33,3 +33,19 @@ class UserPreferenceSerializer(serializers.Serializer):
         if 'tone' not in attrs and 'title' not in attrs:
             raise serializers.ValidationError("Provide at least one of 'tone' or 'title'.")
         return attrs
+
+
+class FrontendSignupSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=150)
+    nickname = serializers.CharField(max_length=150)
+    email = serializers.EmailField()
+    password = serializers.CharField(min_length=8, max_length=128)
+
+    def validate_name(self, value):
+        return value.strip()
+
+    def validate_nickname(self, value):
+        return value.strip()
+
+    def validate_email(self, value):
+        return value.strip().lower()

--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -15,7 +15,7 @@ from dj_rest_auth.jwt_auth import JWTCookieAuthentication
 from .models import Message, ChatMemory, HariKnowledge, GeneratedContent, VisitLog, UserPersona
 from .serializers import (
     MessageSerializer, ChatMemorySerializer, UserNameSerializer,
-    UserPreferenceSerializer,
+    UserPreferenceSerializer, FrontendSignupSerializer,
 )
 
 
@@ -161,6 +161,48 @@ def user_preference_view(request):
     update_user_preference(user.id, **kwargs)
 
     return Response(_current(), status=status.HTTP_200_OK)
+
+
+@api_view(['POST'])
+@perm_classes([permissions.AllowAny])
+def frontend_signup_view(request):
+    serializer = FrontendSignupSerializer(data=request.data)
+    serializer.is_valid(raise_exception=True)
+
+    data = serializer.validated_data
+    AuthUser = get_user_model()
+    email = data['email']
+    nickname = data['nickname']
+
+    if AuthUser.objects.filter(email__iexact=email).exists():
+        return Response(
+            {'email': ['이미 가입된 이메일입니다.']},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    if AuthUser.objects.filter(username__iexact=nickname).exists():
+        return Response(
+            {'username': ['이미 사용 중인 닉네임입니다.']},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    user = AuthUser.objects.create_user(
+        username=nickname,
+        email=email,
+        password=data['password'],
+        first_name=data['name'],
+    )
+
+    try:
+        from .memory_extractor import update_user_preference
+        update_user_preference(user.id, name=data['name'])
+    except Exception:
+        pass
+
+    return Response(
+        {'detail': '회원가입이 완료되었습니다.'},
+        status=status.HTTP_201_CREATED,
+    )
 
 
 def login_view(request):

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -20,7 +20,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.views.generic import RedirectView
 from django.http import HttpResponse
-from chat.views import health_check, homepage, mypage, frontend_chat, admin_dashboard, admin_toggle_content, admin_toggle_knowledge, abouthari_page, gallery_page, news_page, video_page, membership_page, contact_form
+from chat.views import health_check, homepage, mypage, frontend_chat, admin_dashboard, admin_toggle_content, admin_toggle_knowledge, abouthari_page, gallery_page, news_page, video_page, membership_page, contact_form, frontend_signup_view
 
 
 def robots_txt(_request):
@@ -51,6 +51,7 @@ urlpatterns = [
     path('google840fb0dac52a59f6.html', google_verify),
     path('accounts/', include('allauth.urls')),
     path('api/auth/', include('dj_rest_auth.urls')),
+    path('api/auth/registration/', frontend_signup_view, name='frontend_registration'),
     path('api/auth/registration/', include('dj_rest_auth.registration.urls')),
     path('api/chat/', include('chat.urls')),
     path('api/roleplay/', include('roleplay.urls')),

--- a/backend/templates/frontend/homepage.html
+++ b/backend/templates/frontend/homepage.html
@@ -1614,48 +1614,36 @@ function checkPasswordValidity(password){
 function doSignup(){
   const btn=document.querySelector('#panel-signup .auth-submit');
   const panel=document.getElementById('panel-signup');
-  const name=panel.querySelectorAll('.auth-inp')[0].value;
-  const nickname=panel.querySelectorAll('.auth-inp')[1].value;
-  const email=panel.querySelector('input[type="email"]').value;
+  const name=panel.querySelectorAll('.auth-inp')[0].value.trim();
+  const nickname=panel.querySelectorAll('.auth-inp')[1].value.trim();
+  const email=panel.querySelector('input[type="email"]').value.trim();
   const pw=document.getElementById('signup-pw').value;
   const agreed=panel.querySelector('input[type="checkbox"][required]');
 
-  // 임시: 프론트엔드 입력 검증 로직 제거 (개발 편의)
-  /*
-  if(!email||!pw){alert('이메일과 비밀번호를 입력해주세요.');return;}
-  if(!window.emailValidated){alert('이메일 검증을 완료해주세요.');return;}
-  if(!window.passwordValidated){alert('비밀번호 검증을 완료해주세요.');return;}
-  */
-  if(!agreed.checked){alert('이용약관에 동의해주세요.');return;}
+  if(!email||!pw||!name||!nickname){alert('\uBAA8\uB4E0 \uD544\uB4DC\uB97C \uC785\uB825\uD574\uC8FC\uC138\uC694.');return;}
+  if(!agreed.checked){alert('\uC774\uC6A9\uC57D\uAD00\uC5D0 \uB3D9\uC758\uD574\uC8FC\uC138\uC694.');return;}
 
-  btn.textContent='가입 중...'; btn.disabled=true;
+  btn.textContent='\uAC00\uC785 \uC911...'; btn.disabled=true;
 
-  // 임시: 백엔드 모의 동작 (api연동 전 임시 모드)
-  setTimeout(()=>{
-    alert('회원가입 완료! (현재 백엔드 연동 전이므로 로컬 테스트 모드로 넘어갑니다.)');
-    window.location.reload();
-  }, 500);
-
-  /*
   fetch('/api/auth/registration/',{
     method:'POST',
     headers:{'Content-Type':'application/json','X-CSRFToken':getCookie('csrftoken')},
-    body:JSON.stringify({username:nickname||email.split('@')[0],email:email,password1:pw,password2:pw,first_name:name})
+    body:JSON.stringify({nickname:nickname,email:email,password:pw,name:name})
   }).then(r=>{
     if(!r.ok) return r.json().then(d=>{throw d;});
     return r.json();
   }).then(()=>{
     window.location.reload();
   }).catch(err=>{
-    btn.textContent='가입하기 →'; btn.disabled=false;
-    const msg=err.username?err.username[0]
-      :err.email?err.email[0]
-      :err.password1?err.password1[0]
+    btn.textContent='\uAC00\uC785\uD558\uAE30 \u2192'; btn.disabled=false;
+    const msg=err.username?(Array.isArray(err.username)?err.username[0]:err.username)
+      :err.email?(Array.isArray(err.email)?err.email[0]:err.email)
+      :err.password?(Array.isArray(err.password)?err.password[0]:err.password)
       :err.non_field_errors?err.non_field_errors[0]
-      :'회원가입에 실패했습니다.';
+      :err.detail?err.detail
+      :'\uD68C\uC6D0\uAC00\uC785\uC5D0 \uC2E4\uD328\uD588\uC2B5\uB2C8\uB2E4.';
     alert(msg);
   });
-  */
 }
 function doForgot(){
   const btn=document.querySelector('#panel-forgot .auth-submit');

--- a/backend/templates/frontend/signup.html
+++ b/backend/templates/frontend/signup.html
@@ -439,35 +439,17 @@ function doSignup(){
   hideError();
 
   if(!email || !pw || !name || !nick){
-    showError('모든 필드를 입력해주세요.');
+    showError('\uBAA8\uB4E0 \uD544\uB4DC\uB97C \uC785\uB825\uD574\uC8FC\uC138\uC694.');
     return;
   }
-  // 임시: 프론트엔드 검증 생략 (개발 편의)
-  /*
-  if(!window.emailValidated){
-    showError('이메일 검증을 완료해주세요.');
-    return;
-  }
-  if(pw.length < 8){
-    showError('비밀번호는 8자 이상이어야 합니다.');
-    return;
-  }
-  */
   if(!agree){
-    showError('이용약관에 동의해주세요.');
+    showError('\uC774\uC6A9\uC57D\uAD00\uC5D0 \uB3D9\uC758\uD574\uC8FC\uC138\uC694.');
     return;
   }
 
-  btn.textContent = '가입 중...';
+  btn.textContent = '\uAC00\uC785 \uC911...';
   btn.disabled = true;
 
-  // 임시: 백엔드 API 호출 생략하고 바로 가입 성공 처리 (개발 편의)
-  setTimeout(() => {
-    alert('회원가입 완료! (현재 백엔드 연동 전이므로 테스트 모드로 넘어갑니다.)');
-    window.location.href = '{% url "login_page" %}';
-  }, 500);
-
-  /*
   fetch('/api/auth/registration/', {
     method: 'POST',
     headers: {
@@ -475,11 +457,10 @@ function doSignup(){
       'X-CSRFToken': getCookie('csrftoken'),
     },
     body: JSON.stringify({
-      username: nick,
+      nickname: nick,
       email: email,
-      password1: pw,
-      password2: pw,
-      first_name: name
+      password: pw,
+      name: name
     }),
   })
   .then(r => {
@@ -487,23 +468,23 @@ function doSignup(){
     return r.json();
   })
   .then(() => {
-    alert('회원가입이 완료되었습니다! 로그인해주세요.');
+    alert('\uD68C\uC6D0\uAC00\uC785\uC774 \uC644\uB8CC\uB418\uC5C8\uC2B5\uB2C8\uB2E4! \uB85C\uADF8\uC778\uD574\uC8FC\uC138\uC694.');
     window.location.href = '{% url "login_page" %}';
   })
   .catch(err => {
-    btn.textContent = '가입하기 →';
+    btn.textContent = '\uAC00\uC785\uD558\uAE30 \u2192';
     btn.disabled = false;
-    let msg = '회원가입에 실패했습니다.';
-    if(err.username) msg = '이미 사용 중인 닉네임입니다.';
-    else if(err.email) msg = '이미 가입된 이메일입니다.';
-    else if(err.password1) msg = err.password1[0];
+    let msg = '\uD68C\uC6D0\uAC00\uC785\uC5D0 \uC2E4\uD328\uD588\uC2B5\uB2C8\uB2E4.';
+    if(err.username) msg = Array.isArray(err.username) ? err.username[0] : err.username;
+    else if(err.email) msg = Array.isArray(err.email) ? err.email[0] : err.email;
+    else if(err.password) msg = Array.isArray(err.password) ? err.password[0] : err.password;
     else if(err.non_field_errors) msg = err.non_field_errors[0];
+    else if(err.detail) msg = err.detail;
     showError(msg);
   });
-  */
 }
 
-// 이메일 검증 전역 상태
+// Email validation state
 window.emailValidated = false;
 let emailCheckTimeout;
 


### PR DESCRIPTION
## 작업 내용

프론트 회원가입 페이지가 테스트 모드로 남아 있어, 가입 버튼 클릭 시 안내 문구만 출력되고 실제 회원 정보가 DB에 저장되지 않던 문제를 수정했습니다.

이번 변경으로 프론트 회원가입 흐름이 실제 백엔드 API를 호출하도록 연결되며, 이메일 실존 검증은 임시로 우회하되 회원 생성 자체는 정상적으로 처리되도록 정리했습니다.

## 주요 변경 사항

- `frontend/signup.html`의 테스트용 `setTimeout` 성공 분기 제거
- `frontend/homepage.html` 내 회원가입 모달의 테스트용 분기 제거
- 프론트 회원가입 요청을 실제 `/api/auth/registration/` 호출로 연결
- 프론트 전용 회원가입 serializer / view 추가
- 회원가입 시 아래 정보 저장 처리
  - `username`: 닉네임
  - `email`: 입력 이메일
  - `password`: 입력 비밀번호
  - `first_name`: 입력 이름
- 이메일 중복 / 닉네임 중복에 대한 에러 응답 처리 추가
- 가입 완료 후 로그인 가능 여부까지 로컬 서버에서 확인

## 테스트

로컬 환경(`hari22`)에서 실제 서버 기준으로 확인했습니다.

- `POST /api/auth/registration/` -> `201 Created`
- 가입한 계정으로 `POST /api/auth/login/` -> `200 OK`
- JWT / auth cookie 발급 확인
- 실제 DB 저장 및 로그인 가능 상태 확인

## 참고

현재는 이메일 "실존 여부" 검증 로직 구현 중이므로, 해당 단계는 임시로 건너뛰고 가입이 가능하도록 처리했습니다.
즉, 이메일 형식 / 중복 여부는 체크하지만, 외부 메일 검증 API 또는 인증 코드 확인 단계는 아직 강제하지 않습니다.

## 추후 이메일 검증 로직 추가 시 변경 가이드

이메일 검증이 완료되면 아래 순서로 다시 강화하면 됩니다.

1. 프론트 검증 복구
- `signup.html` / `homepage.html`에서 현재 주석 또는 완화된 상태인 이메일 검증 조건을 다시 활성화
- 예:
  - `window.emailValidated` 확인
  - 필요 시 인증 코드 확인 완료 여부(`emailVerificationPassed`) 같은 별도 상태값으로 분리

2. 백엔드 검증 추가
- 현재 프론트 전용 가입 API(`frontend_signup_view`)에서 바로 `create_user()` 하는 구조이므로,
  이메일 검증 완료 여부를 서버에서도 반드시 확인하도록 보강 필요
- 예:
  - 인증 세션/토큰/캐시 값 확인 후에만 가입 허용
  - 검증되지 않은 이메일이면 `400` 반환

3. 중복 검증과 실존 검증 역할 분리
- `verify-email` 단계:
  - 이메일 형식 확인
  - 중복 여부 확인
  - 인증 메일 발송 또는 외부 검증 처리
- `registration` 단계:
  - 검증 완료된 이메일인지 최종 확인
  - 회원 생성 수행

4. 프론트 요청 payload 확장 가능
- 필요하면 가입 시 아래 값 추가 가능
  - `verification_token`
  - `verification_code`
  - `email_verified: true`
- 단, 최종 신뢰는 프론트 값이 아니라 서버 저장 상태를 기준으로 해야 함

## 영향 범위

- 회원가입 전용 프론트 페이지
- 홈페이지 내 회원가입 모달
- 프론트 회원가입 API 진입점

## 비고

이번 PR은 "회원가입이 실제 저장되지 않는 문제"를 우선 해결하는 목적입니다.
이후 이메일 검증 기능이 완성되면, 현재 가입 API에 검증 완료 조건을 다시 연결하는 후속 PR이 필요합니다.
