### PR TITLE
Feat: 어드민 대시보드 SNS 통계 연동 (YouTube Analytics, Instagram, TikTok)

### DIFF
--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -761,6 +761,88 @@ def instagram_stats_api(request):
     })
 
 
+@staff_member_required
+def tiktok_oauth_start(request):
+    """TikTok OAuth2 인증 시작 — TikTok 로그인 페이지로 리다이렉트."""
+    from urllib.parse import urlencode
+    if not settings.TIKTOK_CLIENT_KEY:
+        return JsonResponse({'error': 'TIKTOK_CLIENT_KEY not configured'}, status=500)
+    params = {
+        'client_key':     settings.TIKTOK_CLIENT_KEY,
+        'redirect_uri':   'https://chatting-hari.com/admin/tiktok-oauth-callback/',
+        'response_type':  'code',
+        'scope':          'user.info.basic,user.info.stats',
+    }
+    return redirect('https://www.tiktok.com/v2/auth/authorize/?' + urlencode(params))
+
+
+@staff_member_required
+def tiktok_oauth_callback(request):
+    """TikTok OAuth2 콜백 — 인가 코드를 토큰으로 교환 후 캐시에 저장."""
+    import json, time
+    import urllib.request as urlreq
+    from urllib.parse import urlencode
+    from django.core.cache import cache
+
+    if request.GET.get('error') or not request.GET.get('code'):
+        return redirect('/admin/?tiktok_auth=error')
+
+    body = urlencode({
+        'client_key':     settings.TIKTOK_CLIENT_KEY,
+        'client_secret':  settings.TIKTOK_CLIENT_SECRET,
+        'code':           request.GET['code'],
+        'grant_type':     'authorization_code',
+        'redirect_uri':   'https://chatting-hari.com/admin/tiktok-oauth-callback/',
+    }).encode()
+    try:
+        req = urlreq.Request(
+            'https://open.tiktokapis.com/v2/oauth/token/',
+            data=body,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            method='POST',
+        )
+        with urlreq.urlopen(req, timeout=10) as resp:
+            tokens = json.loads(resp.read())
+    except Exception:
+        return redirect('/admin/?tiktok_auth=error')
+
+    tokens['expires_at'] = time.time() + tokens.get('expires_in', 86400)
+    cache.set('tiktok_oauth_tokens', tokens, 60 * 60 * 24 * 90)
+    return redirect('/admin/?tiktok_auth=success')
+
+
+@staff_member_required
+def tiktok_stats_api(request):
+    """TikTok API — 팔로워 수, 좋아요 수, 영상 수 반환 (staff only)."""
+    import json
+    import urllib.request as urlreq
+    import urllib.error
+    from urllib.parse import urlencode
+    from django.core.cache import cache
+
+    tokens = cache.get('tiktok_oauth_tokens')
+    if not tokens:
+        return JsonResponse({'error': 'not_authenticated'}, status=401)
+
+    access_token = tokens.get('access_token')
+    try:
+        url = 'https://open.tiktokapis.com/v2/user/info/?fields=follower_count,following_count,likes_count,video_count'
+        req = urlreq.Request(url, headers={'Authorization': f'Bearer {access_token}'})
+        with urlreq.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return JsonResponse({'error': f'TikTok API error: {e.code}'}, status=502)
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=502)
+
+    user = data.get('data', {}).get('user', {})
+    return JsonResponse({
+        'follower_count':  user.get('follower_count', 0),
+        'likes_count':     user.get('likes_count', 0),
+        'video_count':     user.get('video_count', 0),
+    })
+
+
 @require_POST
 def admin_toggle_content(request, content_id):
     if not settings.DEBUG:

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -293,6 +293,10 @@ INSTAGRAM_APP_ID = os.environ.get('INSTAGRAM_APP_ID', '')
 INSTAGRAM_APP_SECRET = os.environ.get('INSTAGRAM_APP_SECRET', '')
 INSTAGRAM_ACCESS_TOKEN = os.environ.get('INSTAGRAM_ACCESS_TOKEN', '')
 
+# TikTok API
+TIKTOK_CLIENT_KEY = os.environ.get('TIKTOK_CLIENT_KEY', '')
+TIKTOK_CLIENT_SECRET = os.environ.get('TIKTOK_CLIENT_SECRET', '')
+
 
 # Logging Configuration
 LOGGING = {

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -21,7 +21,7 @@ from django.conf.urls.static import static
 from django.views.generic import RedirectView
 from django.views.static import serve
 from django.http import HttpResponse
-from chat.views import health_check, homepage, mypage, frontend_chat, abouthari_page, gallery_page, news_page, video_page, membership_page, contact_form, frontend_signup_view, admin_stats_api, youtube_stats_api, youtube_oauth_start, youtube_oauth_callback, youtube_analytics_api, youtube_video_analytics_api, instagram_stats_api
+from chat.views import health_check, homepage, mypage, frontend_chat, abouthari_page, gallery_page, news_page, video_page, membership_page, contact_form, frontend_signup_view, admin_stats_api, youtube_stats_api, youtube_oauth_start, youtube_oauth_callback, youtube_analytics_api, youtube_video_analytics_api, instagram_stats_api, tiktok_oauth_start, tiktok_oauth_callback, tiktok_stats_api
 
 
 def robots_txt(_request):
@@ -54,10 +54,14 @@ urlpatterns = [
     path('admin/youtube-analytics/', youtube_analytics_api, name='youtube_analytics_api'),
     path('admin/youtube-video-analytics/', youtube_video_analytics_api, name='youtube_video_analytics_api'),
     path('admin/instagram-stats/', instagram_stats_api, name='instagram_stats_api'),
+    path('admin/tiktok-oauth-start/', tiktok_oauth_start, name='tiktok_oauth_start'),
+    path('admin/tiktok-oauth-callback/', tiktok_oauth_callback, name='tiktok_oauth_callback'),
+    path('admin/tiktok-stats/', tiktok_stats_api, name='tiktok_stats_api'),
     path('admin/', admin.site.urls),
     path('favicon.ico', RedirectView.as_view(url='/static/images/hari_favicon.png', permanent=True)),
     path('robots.txt', robots_txt),
     path('tiktokhUjyVzNan045mImBqBP0HionITouB7wa.txt', tiktok_verify),
+    path('admin/tiktok-oauth-callback/tiktokhUjyVzNan045mImBqBP0HionITouB7wa.txt', tiktok_verify),
 
     path('google840fb0dac52a59f6.html', google_verify),
     path('accounts/', include('allauth.urls')),

--- a/backend/templates/admin/index.html
+++ b/backend/templates/admin/index.html
@@ -89,11 +89,11 @@
   /* 통계 카드 */
   .stat-row {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(6, 1fr);
     gap: 14px;
     margin-bottom: 20px;
   }
-  @media (max-width: 1100px) { .stat-row { grid-template-columns: repeat(3, 1fr); } }
+  @media (max-width: 1200px) { .stat-row { grid-template-columns: repeat(3, 1fr); } }
   @media (max-width: 700px)  { .stat-row { grid-template-columns: repeat(2, 1fr); } }
   @media (max-width: 420px)  { .stat-row { grid-template-columns: 1fr; } }
 
@@ -118,6 +118,7 @@
   .stat-card.c-purple::before  { background: #a855f7; }
   .stat-card.c-fuchsia::before { background: #d946ef; }
   .stat-card.c-insta::before   { background: linear-gradient(90deg, #f58529, #dd2a7b, #8134af); }
+  .stat-card.c-tiktok::before  { background: linear-gradient(90deg, #010101, #fe2c55, #69c9d0); }
 
   .stat-card:hover {
     border-color: #f0b8c8;
@@ -140,6 +141,7 @@
   .ic-purple  { background: #faf5ff; color: #a855f7; }
   .ic-fuchsia { background: #fdf4ff; color: #d946ef; }
   .ic-insta   { background: #fff4fb; color: #dd2a7b; }
+  .ic-tiktok  { background: #f0fffe; color: #010101; }
 
   .stat-label {
     font-size: 0.7rem;
@@ -269,6 +271,14 @@
       <div class="stat-label">Instagram 팔로워</div>
       <div class="stat-value" id="stat-instagram">—</div>
       <div class="stat-sub" id="stat-instagram-sub">@jeondal__hari</div>
+    </div>
+    <div class="stat-card c-tiktok">
+      <div class="stat-card-icon ic-tiktok">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-2.88 2.5 2.89 2.89 0 0 1-2.89-2.89 2.89 2.89 0 0 1 2.89-2.89c.28 0 .54.04.79.1V9.01a6.27 6.27 0 0 0-.79-.05 6.34 6.34 0 0 0-6.34 6.34 6.34 6.34 0 0 0 6.34 6.34 6.34 6.34 0 0 0 6.33-6.34V8.69a8.18 8.18 0 0 0 4.78 1.52V6.75a4.85 4.85 0 0 1-1.01-.06z"/></svg>
+      </div>
+      <div class="stat-label">TikTok 팔로워</div>
+      <div class="stat-value" id="stat-tiktok">—</div>
+      <div class="stat-sub" id="stat-tiktok-sub">@coding__hari</div>
     </div>
   </div>
 
@@ -630,6 +640,26 @@ async function loadAnalytics(period) {
   } catch (e) {}
 }
 
+/* ── TikTok 실데이터 로드 ── */
+async function loadTikTok() {
+  try {
+    var resp = await fetch('/admin/tiktok-stats/');
+    if (resp.status === 401) {
+      document.getElementById('stat-tiktok-sub').innerHTML = '<a href="/admin/tiktok-oauth-start/" style="color:#fe2c55;">🎵 TikTok 연동</a>';
+      return;
+    }
+    if (resp.ok) {
+      var data = await resp.json();
+      if (!data.error) {
+        document.getElementById('stat-tiktok').textContent = fmt(data.follower_count || 0);
+        document.getElementById('stat-tiktok-sub').textContent = '좋아요 ' + fmt(data.likes_count || 0) + ' · @coding__hari';
+      } else {
+        document.getElementById('stat-tiktok-sub').innerHTML = '<a href="/admin/tiktok-oauth-start/" style="color:#fe2c55;">🎵 TikTok 연동</a>';
+      }
+    }
+  } catch (e) {}
+}
+
 /* ── Instagram 실데이터 로드 ── */
 async function loadInstagram() {
   try {
@@ -661,7 +691,7 @@ async function loadDashboard() {
   } catch (e) {
     console.error('Dashboard data load failed:', e);
   }
-  await Promise.all([loadAnalytics('daily'), loadInstagram()]);
+  await Promise.all([loadAnalytics('daily'), loadInstagram(), loadTikTok()]);
   buildCharts('daily');
 
   /* URL 파라미터로 OAuth 결과 안내 */


### PR DESCRIPTION
- YouTube Analytics API OAuth2 연동 및 기간별 조회수·좋아요·댓글 차트 추가
- Instagram Graph API 연동 — 팔로워 수, 게시물 수 카드 표시
- TikTok OAuth2 연동 — 팔로워 수, 좋아요 수 카드 표시
- TikTok 도메인 인증 URL 추가