### PR TITLE
Fix: 채팅 페이지 모바일 레이아웃 너비 잘림 현상 수정

### DIFF
--- a/backend/templates/frontend/chat.html
+++ b/backend/templates/frontend/chat.html
@@ -3,7 +3,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>하리와의 대화</title>
 <link rel="icon" type="image/png" href="{% static 'images/hari_favicon.png' %}?v=2">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/NeoDunggeunmo.css">
@@ -116,6 +116,8 @@ html[data-theme="dark"] .back-btn:hover {
 
 html, body {
   height: 100vh;
+  height: 100dvh;
+  width: 100%;
   margin: 0;
   overflow: hidden;
   overflow-x: hidden;
@@ -131,8 +133,8 @@ html, body {
 .app-container {
   display: flex;
   height: 100vh;
+  height: 100dvh;
   width: 100%;
-  max-width: 100vw;
   overflow: hidden;
 }
 
@@ -175,6 +177,8 @@ html, body {
    ═══════════════════════════════════════ */
 .chat-main {
   flex: 1;
+  min-width: 0;
+  width: 100%;
   display: flex;
   flex-direction: column;
   background: var(--bg-gradient);
@@ -1039,6 +1043,7 @@ html[data-theme="dark"] .date-divider-text {
   backdrop-filter: blur(20px);
   border-top: 0.5px solid var(--border);
   padding: 16px 24px;
+  padding-bottom: max(16px, env(safe-area-inset-bottom));
   display: flex;
   align-items: flex-end;
   gap: 12px;
@@ -1217,7 +1222,7 @@ html[data-theme="dark"] .date-divider-text {
 }
 /* 1024px: 레이아웃 풀너비 */
 @media (max-width: 1024px) {
-  .app-container { width: 100vw; }
+  .app-container { width: 100%; }
   .sidebar-left { width: 260px; }
 }
 /* 768px: 태블릿 — 좌측 사이드바 숨김 */


### PR DESCRIPTION
- 100vw → 100%로 교체하여 스크롤바 너비 포함 계산 오류 해결
- app-container의 max-width: 100vw 제거
- chat-main에 width: 100% 추가로 container-type 충돌 방지
- 100dvh 적용 및 safe-area-inset-bottom으로 iOS 하단 잘림 대응