### PR TITLE
Feat: 인스타그램 조회수 수정 및 토큰 자동 갱신 시스템 구현

### DIFF
--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -603,20 +603,35 @@ def youtube_analytics_api(request):
     if not access_token:
         return JsonResponse({'error': 'not_authenticated'}, status=401)
 
-    period = request.GET.get('period', 'daily')
-    today  = timezone.now().date()
+    period  = request.GET.get('period', 'daily')
+    try:
+        range_n = int(request.GET.get('range', 0))
+    except (ValueError, TypeError):
+        range_n = 0
+    today   = timezone.now().date()
 
     if period == 'daily':
-        start_date = today - timedelta(days=6)
+        days       = range_n if range_n in (7, 14, 30) else 7
+        start_date = today - timedelta(days=days - 1)
         dimension  = 'day'
     elif period == 'weekly':
-        start_date = today - timedelta(weeks=8)
-        dimension  = 'day'
+        weeks       = range_n if range_n in (4, 8, 12) else 8
+        current_mon = today - timedelta(days=today.weekday())
+        start_date  = current_mon - timedelta(weeks=weeks - 1)
+        dimension   = 'day'
     elif period == 'monthly':
-        start_date = date_type(today.year - 1, today.month, 1)
+        months = range_n if range_n in (6, 12, 24) else 12
+        sm = today.month - months
+        sy = today.year + sm // 12
+        sm = sm % 12
+        if sm == 0:
+            sm = 12
+            sy -= 1
+        start_date = date_type(sy, sm, 1)
         dimension  = 'month'
     else:  # yearly
-        start_date = date_type(today.year - 3, 1, 1)
+        years      = range_n if range_n in (2, 3, 5) else 3
+        start_date = date_type(today.year - years, 1, 1)
         dimension  = 'month'
 
     api_url = (
@@ -642,28 +657,38 @@ def youtube_analytics_api(request):
     rows = data.get('rows') or []
 
     if period == 'daily':
-        labels   = [r[0][5:].replace('-', '/') for r in rows]   # YYYY-MM-DD → M/D
+        # YYYY-MM-DD → "4월 10일"
+        labels   = [f"{int(r[0][5:7])}월 {int(r[0][8:])}일" for r in rows]
         views    = [r[1] for r in rows]
         likes    = [r[2] for r in rows]
         comments = [r[3] for r in rows]
 
     elif period == 'weekly':
+        weeks       = range_n if range_n in (4, 8, 12) else 8
         current_mon = today - timedelta(days=today.weekday())
         week_data   = defaultdict(lambda: [0, 0, 0])
         for r in rows:
-            d = date_type(*[int(x) for x in r[0].split('-')])
-            wi = (current_mon - d).days // 7   # 0=이번주 … 7=8주전
-            if 0 <= wi <= 7:
+            d     = date_type(*[int(x) for x in r[0].split('-')])
+            d_mon = d - timedelta(days=d.weekday())
+            wi    = (current_mon - d_mon).days // 7             # 0=이번주
+            if 0 <= wi <= weeks - 1:
                 week_data[wi][0] += r[1]
                 week_data[wi][1] += r[2]
                 week_data[wi][2] += r[3]
-        labels   = [f'W{i + 1}' for i in range(8)]
-        views    = [week_data[7 - i][0] for i in range(8)]
-        likes    = [week_data[7 - i][1] for i in range(8)]
-        comments = [week_data[7 - i][2] for i in range(8)]
+        week_starts = [current_mon - timedelta(weeks=weeks - 1 - i) for i in range(weeks)]
+        # "4월 14일주" 형식
+        labels   = [f'{ws.month}월 {ws.day}일주' for ws in week_starts]
+        views    = [week_data[weeks - 1 - i][0] for i in range(weeks)]
+        likes    = [week_data[weeks - 1 - i][1] for i in range(weeks)]
+        comments = [week_data[weeks - 1 - i][2] for i in range(weeks)]
 
     elif period == 'monthly':
-        labels   = [r[0][5:].lstrip('0') + '월' for r in rows]  # YYYY-MM → M월
+        # 연도가 2개 이상 걸치면 "'25년 4월" 형식, 단일 연도면 "4월"
+        row_years = {r[0][:4] for r in rows}
+        if len(row_years) > 1:
+            labels = [f"'{r[0][2:4]}년 {int(r[0][5:7])}월" for r in rows]
+        else:
+            labels = [f"{int(r[0][5:7])}월" for r in rows]
         views    = [r[1] for r in rows]
         likes    = [r[2] for r in rows]
         comments = [r[3] for r in rows]
@@ -696,17 +721,31 @@ def youtube_video_analytics_api(request):
     if not access_token:
         return JsonResponse({'error': 'not_authenticated'}, status=401)
 
-    period = request.GET.get('period', 'daily')
-    today  = timezone.now().date()
+    period  = request.GET.get('period', 'daily')
+    try:
+        range_n = int(request.GET.get('range', 0))
+    except (ValueError, TypeError):
+        range_n = 0
+    today   = timezone.now().date()
 
     if period == 'daily':
-        start_date = today - timedelta(days=6)
+        days       = range_n if range_n in (7, 14, 30) else 7
+        start_date = today - timedelta(days=days - 1)
     elif period == 'weekly':
-        start_date = today - timedelta(weeks=8)
+        weeks      = range_n if range_n in (4, 8, 12) else 8
+        start_date = today - timedelta(days=today.weekday()) - timedelta(weeks=weeks - 1)
     elif period == 'monthly':
-        start_date = date_type(today.year - 1, today.month, 1)
+        months = range_n if range_n in (6, 12, 24) else 12
+        sm = today.month - months
+        sy = today.year + sm // 12
+        sm = sm % 12
+        if sm == 0:
+            sm = 12
+            sy -= 1
+        start_date = date_type(sy, sm, 1)
     else:
-        start_date = date_type(today.year - 3, 1, 1)
+        years      = range_n if range_n in (2, 3, 5) else 3
+        start_date = date_type(today.year - years, 1, 1)
 
     api_url = (
         'https://youtubeanalytics.googleapis.com/v2/reports?'
@@ -734,6 +773,97 @@ def youtube_video_analytics_api(request):
     return JsonResponse({'videos': result})
 
 
+# ──────────────────────────────────────────────
+# Instagram 공통: 토큰 관리
+# ──────────────────────────────────────────────
+
+def _instagram_token():
+    """캐시에서 Instagram 장기 토큰을 가져오고, 만료 7일 이내면 자동 갱신."""
+    import json, time
+    import urllib.request as urlreq
+    from django.core.cache import cache
+
+    env_token = getattr(settings, 'INSTAGRAM_ACCESS_TOKEN', '')
+    cached = cache.get('ig_token_data')
+
+    if cached:
+        token = cached.get('token') or env_token
+        exp = cached.get('expires_at', 0)
+        if (exp - time.time()) > 7 * 86400:
+            return token
+    else:
+        token = env_token
+
+    if not token:
+        return ''
+
+    # 갱신 시도
+    try:
+        refresh_url = (
+            'https://graph.instagram.com/refresh_access_token'
+            f'?grant_type=ig_refresh_token&access_token={token}'
+        )
+        with urlreq.urlopen(refresh_url, timeout=10) as resp:
+            d = json.loads(resp.read())
+        new_token = d.get('access_token', token)
+        expires_in = d.get('expires_in', 5184000)  # 기본 60일
+        cache.set('ig_token_data', {
+            'token': new_token,
+            'expires_at': time.time() + expires_in,
+        }, timeout=expires_in + 86400)
+        return new_token
+    except Exception:
+        return token  # 갱신 실패해도 기존 토큰 사용
+
+
+@staff_member_required
+def instagram_token_api(request):
+    """Instagram 토큰 상태 조회(GET) / 수동 갱신(POST)."""
+    import json, time
+    import urllib.request as urlreq
+    import urllib.error
+    from django.core.cache import cache
+
+    env_token = getattr(settings, 'INSTAGRAM_ACCESS_TOKEN', '')
+    cached = cache.get('ig_token_data')
+    token = (cached.get('token') if cached else None) or env_token
+    exp = (cached.get('expires_at', 0) if cached else 0)
+    days_left = int((exp - time.time()) / 86400) if exp else None
+
+    if request.method == 'POST':
+        if not token:
+            return JsonResponse({'error': '토큰이 설정되지 않았습니다.', 'refreshed': False}, status=400)
+        try:
+            refresh_url = (
+                'https://graph.instagram.com/refresh_access_token'
+                f'?grant_type=ig_refresh_token&access_token={token}'
+            )
+            with urlreq.urlopen(refresh_url, timeout=10) as resp:
+                d = json.loads(resp.read())
+            new_token = d.get('access_token', token)
+            expires_in = d.get('expires_in', 5184000)
+            new_exp = time.time() + expires_in
+            cache.set('ig_token_data', {
+                'token': new_token,
+                'expires_at': new_exp,
+            }, timeout=expires_in + 86400)
+            return JsonResponse({
+                'refreshed': True,
+                'days_left': int(expires_in / 86400),
+            })
+        except urllib.error.HTTPError as e:
+            body = e.read().decode('utf-8', errors='replace')
+            return JsonResponse({'error': f'HTTP {e.code}: {body}', 'refreshed': False}, status=502)
+        except Exception as e:
+            return JsonResponse({'error': str(e), 'refreshed': False}, status=502)
+
+    return JsonResponse({
+        'has_token': bool(token),
+        'days_left': days_left,
+        'source': 'cache' if (cached and cached.get('token')) else 'env',
+    })
+
+
 @staff_member_required
 def instagram_stats_api(request):
     """Instagram Graph API — 팔로워 수, 게시물 수 반환 (staff only)."""
@@ -741,7 +871,7 @@ def instagram_stats_api(request):
     import urllib.request as urlreq
     import urllib.error
 
-    access_token = getattr(settings, 'INSTAGRAM_ACCESS_TOKEN', '')
+    access_token = _instagram_token()
     if not access_token:
         return JsonResponse({'error': 'INSTAGRAM_ACCESS_TOKEN not configured'}, status=500)
 
@@ -772,45 +902,70 @@ def instagram_media_api(request):
     import urllib.error
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
-    access_token = getattr(settings, 'INSTAGRAM_ACCESS_TOKEN', '')
+    access_token = _instagram_token()
     if not access_token:
         return JsonResponse({'error': 'INSTAGRAM_ACCESS_TOKEN not configured'}, status=500)
 
     try:
         url = (
             'https://graph.instagram.com/v22.0/me/media'
-            '?fields=id,caption,media_type,timestamp,like_count,comments_count'
+            '?fields=id,caption,media_type,timestamp,like_count,comments_count,video_views'
             '&limit=20'
             f'&access_token={access_token}'
         )
         with urlreq.urlopen(url, timeout=10) as resp:
             data = json.loads(resp.read())
     except urllib.error.HTTPError as e:
-        return JsonResponse({'error': f'Instagram API error: {e.code}'}, status=502)
+        body = e.read().decode('utf-8', errors='replace')
+        return JsonResponse({'error': f'Instagram API {e.code}: {body}'}, status=502)
     except Exception as e:
         return JsonResponse({'error': str(e)}, status=502)
 
     items = data.get('data', [])
 
-    def fetch_views(media_id):
-        insights_url = (
-            f'https://graph.instagram.com/v22.0/{media_id}/insights'
-            f'?metric=views&access_token={access_token}'
-        )
-        try:
-            with urlreq.urlopen(insights_url, timeout=5) as resp:
-                d = json.loads(resp.read())
-                return media_id, d.get('data', [{}])[0].get('values', [{}])[0].get('value', 0)
-        except Exception:
-            return media_id, 0
+    def fetch_insights(media_id, media_type):
+        """Insights API로 노출수 조회. 타입별 메트릭 우선순위를 두고 순서대로 시도."""
+        metrics = ['views', 'impressions', 'reach'] if media_type in ('VIDEO', 'REEL') \
+                  else ['impressions', 'reach']
+        for metric in metrics:
+            insights_url = (
+                f'https://graph.instagram.com/v22.0/{media_id}/insights'
+                f'?metric={metric}&period=lifetime&access_token={access_token}'
+            )
+            try:
+                with urlreq.urlopen(insights_url, timeout=5) as resp:
+                    d = json.loads(resp.read())
+                vals = d.get('data', [{}])[0].get('values', [])
+                if isinstance(vals, list) and vals:
+                    return media_id, int(vals[0].get('value', 0) or 0)
+                if isinstance(vals, (int, float)):
+                    return media_id, int(vals)
+            except urllib.error.HTTPError:
+                continue  # 메트릭 미지원 → 다음 메트릭 시도
+            except Exception:
+                break     # 네트워크 등 다른 오류 → 포기
+        return media_id, 0
 
-    with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = {executor.submit(fetch_views, item['id']): item['id'] for item in items}
-        views_map = {media_id: views for future in as_completed(futures) for media_id, views in [future.result()]}
+    # VIDEO/REEL은 video_views 필드를 우선 사용. 없으면 Insights로 보완.
+    needs_insights = [item for item in items
+                      if item.get('video_views') is None]
+
+    views_map = {}
+    if needs_insights:
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = {
+                executor.submit(fetch_insights, item['id'], item.get('media_type', 'IMAGE')): item['id']
+                for item in needs_insights
+            }
+            for future in as_completed(futures):
+                mid, v = future.result()
+                views_map[mid] = v
 
     media_list = []
     for item in items:
         caption = (item.get('caption') or '').strip().split('\n')[0][:30]
+        vid_views = item.get('video_views')
+        views_val = int(vid_views) if vid_views is not None else views_map.get(item.get('id'), 0)
         media_list.append({
             'id':             item.get('id'),
             'caption':        caption or f"게시물 {str(item.get('id', ''))[-6:]}",
@@ -818,7 +973,7 @@ def instagram_media_api(request):
             'timestamp':      item.get('timestamp', ''),
             'like_count':     item.get('like_count', 0),
             'comments_count': item.get('comments_count', 0),
-            'views':          views_map.get(item.get('id'), 0),
+            'views':          views_val,
         })
 
     return JsonResponse({'media': media_list})

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -21,7 +21,7 @@ from django.conf.urls.static import static
 from django.views.generic import RedirectView
 from django.views.static import serve
 from django.http import HttpResponse
-from chat.views import health_check, homepage, mypage, frontend_chat, abouthari_page, gallery_page, news_page, video_page, membership_page, contact_form, frontend_signup_view, admin_stats_api, youtube_stats_api, youtube_oauth_start, youtube_oauth_callback, youtube_analytics_api, youtube_video_analytics_api, instagram_stats_api, instagram_media_api, tiktok_oauth_start, tiktok_oauth_callback, tiktok_stats_api
+from chat.views import health_check, homepage, mypage, frontend_chat, abouthari_page, gallery_page, news_page, video_page, membership_page, contact_form, frontend_signup_view, admin_stats_api, youtube_stats_api, youtube_oauth_start, youtube_oauth_callback, youtube_analytics_api, youtube_video_analytics_api, instagram_stats_api, instagram_media_api, instagram_token_api, tiktok_oauth_start, tiktok_oauth_callback, tiktok_stats_api
 
 
 def robots_txt(_request):
@@ -55,6 +55,7 @@ urlpatterns = [
     path('admin/youtube-video-analytics/', youtube_video_analytics_api, name='youtube_video_analytics_api'),
     path('admin/instagram-stats/', instagram_stats_api, name='instagram_stats_api'),
     path('admin/instagram-media/', instagram_media_api, name='instagram_media_api'),
+    path('admin/instagram-token/', instagram_token_api, name='instagram_token_api'),
     path('admin/tiktok-oauth-start/', tiktok_oauth_start, name='tiktok_oauth_start'),
     path('admin/tiktok-oauth-callback/', tiktok_oauth_callback, name='tiktok_oauth_callback'),
     path('admin/tiktok-stats/', tiktok_stats_api, name='tiktok_stats_api'),

--- a/backend/templates/admin/index.html
+++ b/backend/templates/admin/index.html
@@ -351,6 +351,31 @@
     border: 1px solid #f5e0e6;
   }
 
+  /* ── 범위 선택 서브 버튼 ── */
+  .range-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    margin-left: 4px;
+    padding-left: 8px;
+    border-left: 1.5px solid #e8d0da;
+  }
+  .range-btn {
+    padding: 3px 10px;
+    border: 1.5px solid #ecd8e2;
+    background: #fff8fa;
+    border-radius: 14px;
+    font-family: inherit;
+    font-size: 0.7rem;
+    font-weight: 500;
+    color: #a07090;
+    cursor: pointer;
+    transition: all 0.13s;
+    white-space: nowrap;
+  }
+  .range-btn:hover { border-color: #e8607a; color: #e8607a; background: #fff4f6; }
+  .range-btn.active { background: rgba(232,96,122,0.13); border-color: #e8607a; color: #e8607a; font-weight: 700; }
+
   /* ── 빈 데이터 메시지 ── */
   .no-data-msg {
     display: flex;
@@ -506,6 +531,26 @@
           <button class="period-btn" data-period="weekly">주간별</button>
           <button class="period-btn" data-period="monthly">월별</button>
           <button class="period-btn" data-period="yearly">연별</button>
+          <span class="range-group" data-for="daily">
+            <button class="range-btn active" data-range="7">7일</button>
+            <button class="range-btn" data-range="14">14일</button>
+            <button class="range-btn" data-range="30">30일</button>
+          </span>
+          <span class="range-group" data-for="weekly" style="display:none">
+            <button class="range-btn active" data-range="4">4주</button>
+            <button class="range-btn" data-range="8">8주</button>
+            <button class="range-btn" data-range="12">12주</button>
+          </span>
+          <span class="range-group" data-for="monthly" style="display:none">
+            <button class="range-btn active" data-range="6">6개월</button>
+            <button class="range-btn" data-range="12">12개월</button>
+            <button class="range-btn" data-range="24">24개월</button>
+          </span>
+          <span class="range-group" data-for="yearly" style="display:none">
+            <button class="range-btn active" data-range="2">2년</button>
+            <button class="range-btn" data-range="3">3년</button>
+            <button class="range-btn" data-range="5">5년</button>
+          </span>
         </div>
       </div>
       <div style="position:relative; height:200px;">
@@ -529,31 +574,71 @@
         <button class="period-btn" data-period="weekly">주간별</button>
         <button class="period-btn" data-period="monthly">월별</button>
         <button class="period-btn" data-period="yearly">연별</button>
+        <span class="range-group" data-for="daily">
+          <button class="range-btn active" data-range="7">7일</button>
+          <button class="range-btn" data-range="14">14일</button>
+          <button class="range-btn" data-range="30">30일</button>
+        </span>
+        <span class="range-group" data-for="weekly" style="display:none">
+          <button class="range-btn active" data-range="4">4주</button>
+          <button class="range-btn" data-range="8">8주</button>
+          <button class="range-btn" data-range="12">12주</button>
+        </span>
+        <span class="range-group" data-for="monthly" style="display:none">
+          <button class="range-btn active" data-range="6">6개월</button>
+          <button class="range-btn" data-range="12">12개월</button>
+          <button class="range-btn" data-range="24">24개월</button>
+        </span>
+        <span class="range-group" data-for="yearly" style="display:none">
+          <button class="range-btn active" data-range="2">2년</button>
+          <button class="range-btn" data-range="3">3년</button>
+          <button class="range-btn" data-range="5">5년</button>
+        </span>
       </div>
 
       <div class="chart-row-half">
         <!-- 영상 성과 TOP 10 -->
         <div class="chart-card">
           <div class="chart-card-title">영상 성과 TOP 10</div>
-          <div class="chart-card-desc">기간 내 조회수 상위 영상 순위</div>
+          <div class="chart-card-desc" id="ytVideosDesc">기간 내 조회수 상위 영상 순위</div>
           <div style="position:relative; height:280px;">
             <canvas id="chartYTVideos"></canvas>
           </div>
         </div>
 
-        <!-- 채널 성장 트렌드 -->
+        <!-- 기간별 조회수 -->
         <div class="chart-card">
           <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:4px;">
             <div>
-              <div class="chart-card-title" id="ytTrendTitle">채널 성장 트렌드</div>
-              <div class="chart-card-desc" id="ytTrendDesc">기간별 조회수 · 좋아요 · 댓글 변화</div>
+              <div class="chart-card-title">기간별 조회수</div>
+              <div class="chart-card-desc" id="ytViewsDesc">채널 기간별 조회수 변화</div>
             </div>
             <a id="ytAuthBtn" href="/admin/youtube-oauth-start/" style="display:none;flex-shrink:0;font-size:0.72rem;padding:5px 12px;background:#fff0f4;border:1px solid #e8607a;border-radius:6px;color:#e8607a;text-decoration:none;white-space:nowrap;margin-top:2px;">
               📊 Google 연동
             </a>
           </div>
-          <div style="position:relative; height:280px;margin-top:0;">
-            <canvas id="chartYTTrend"></canvas>
+          <div style="position:relative; height:280px;">
+            <canvas id="chartYTViews"></canvas>
+          </div>
+        </div>
+      </div>
+
+      <div class="chart-row-half">
+        <!-- 기간별 좋아요 -->
+        <div class="chart-card">
+          <div class="chart-card-title">기간별 좋아요</div>
+          <div class="chart-card-desc" id="ytLikesDesc">채널 기간별 좋아요 변화</div>
+          <div style="position:relative; height:220px;">
+            <canvas id="chartYTLikes"></canvas>
+          </div>
+        </div>
+
+        <!-- 기간별 댓글 -->
+        <div class="chart-card">
+          <div class="chart-card-title">기간별 댓글</div>
+          <div class="chart-card-desc" id="ytCommentsDesc">채널 기간별 댓글 변화</div>
+          <div style="position:relative; height:220px;">
+            <canvas id="chartYTComments"></canvas>
           </div>
         </div>
       </div>
@@ -565,6 +650,8 @@
         <svg viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"/></svg>
         Instagram
         <span class="platform-badge" style="color:#6b21a8;">게시물 분석</span>
+        <span id="igTokenBadge" style="display:none; font-size:11px; font-weight:600; padding:2px 8px; border-radius:20px; margin-left:8px;"></span>
+        <button id="igTokenRefreshBtn" onclick="refreshIgToken()" style="display:none; margin-left:8px; font-size:11px; padding:3px 10px; border-radius:20px; border:1px solid #8134af; color:#8134af; background:#fff; cursor:pointer;">토큰 갱신</button>
       </div>
       <div class="period-bar section-period-bar" data-section="ig">
         <span class="period-bar-label">기간:</span>
@@ -572,6 +659,26 @@
         <button class="period-btn" data-period="weekly">주간별</button>
         <button class="period-btn" data-period="monthly">월별</button>
         <button class="period-btn" data-period="yearly">연별</button>
+        <span class="range-group" data-for="daily">
+          <button class="range-btn active" data-range="7">7일</button>
+          <button class="range-btn" data-range="14">14일</button>
+          <button class="range-btn" data-range="30">30일</button>
+        </span>
+        <span class="range-group" data-for="weekly" style="display:none">
+          <button class="range-btn active" data-range="4">4주</button>
+          <button class="range-btn" data-range="8">8주</button>
+          <button class="range-btn" data-range="12">12주</button>
+        </span>
+        <span class="range-group" data-for="monthly" style="display:none">
+          <button class="range-btn active" data-range="6">6개월</button>
+          <button class="range-btn" data-range="12">12개월</button>
+          <button class="range-btn" data-range="24">24개월</button>
+        </span>
+        <span class="range-group" data-for="yearly" style="display:none">
+          <button class="range-btn active" data-range="2">2년</button>
+          <button class="range-btn" data-range="3">3년</button>
+          <button class="range-btn" data-range="5">5년</button>
+        </span>
       </div>
 
       <div class="chart-row-half">
@@ -712,6 +819,9 @@ var charts = {};
 var YT_ANALYTICS_CACHE       = {};
 var YT_VIDEO_ANALYTICS_CACHE = {};
 
+/* ── 기간별 기본 범위 ── */
+var DEFAULT_RANGE = { daily: 7, weekly: 8, monthly: 12, yearly: 3 };
+
 /* ── 탭/기간 상태 ── */
 var activeTab      = 'main';
 var mainPeriod     = 'daily';
@@ -721,13 +831,44 @@ var igPeriod       = 'daily';
 var tabDirty       = { main: false };
 var snsInitialized = false;
 
+/* ── 섹션별 범위 상태 ── */
+var platformRange = { daily: 7, weekly: 8, monthly: 12, yearly: 3 };
+var ytRange       = { daily: 7, weekly: 8, monthly: 12, yearly: 3 };
+var igRange       = { daily: 7, weekly: 8, monthly: 12, yearly: 3 };
+
 /* ── 차트 스케일 공통 옵션 ── */
-function xScaleOpt() { return { grid: { color: '#f5eaec' }, ticks: { color: '#c090a0', font: { size: 11 } } }; }
+function xScaleOpt() { return { grid: { color: '#f5eaec' }, ticks: { color: '#c090a0', font: { size: 11 }, maxRotation: 30 } }; }
 function yScaleOpt(fmt_cb) {
   return {
+    min: 0,
     grid: { color: '#f5eaec' },
-    ticks: { color: '#c090a0', font: { size: 11 }, callback: fmt_cb || undefined }
+    ticks: { color: '#c090a0', font: { size: 11 }, callback: fmt_cb || function(v){ return fmt(v); } }
   };
+}
+
+/* ── 모든 값이 0인지 확인 ── */
+function isAllZero(arr) { return !arr || arr.length === 0 || arr.every(function(v){ return !v || v === 0; }); }
+
+/* ── 캔버스 래퍼에 "데이터 없음" 오버레이 표시/제거 ── */
+function setNoData(canvasId, show, msg) {
+  var canvas = document.getElementById(canvasId);
+  if (!canvas) return;
+  var wrap = canvas.parentElement;
+  var overId = canvasId + '_nodata';
+  var existing = document.getElementById(overId);
+  if (show) {
+    canvas.style.opacity = '0';
+    if (!existing) {
+      var el = document.createElement('div');
+      el.id = overId;
+      el.style.cssText = 'position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#c090a0;font-size:0.82rem;pointer-events:none;';
+      el.textContent = msg || '데이터 없음';
+      wrap.appendChild(el);
+    }
+  } else {
+    canvas.style.opacity = '1';
+    if (existing) existing.remove();
+  }
 }
 
 /* ════════════════════════════════════════════════
@@ -769,11 +910,15 @@ function buildMainCharts(period) {
 /* ════════════════════════════════════════════════
    플랫폼 비교 차트 빌드 (YouTube + Instagram만)
    ════════════════════════════════════════════════ */
-function buildPlatformChart(period) {
-  var _ytAnalytics = YT_ANALYTICS_CACHE[period];
+function buildPlatformChart(period, range) {
+  var r = range || DEFAULT_RANGE[period] || 7;
+  var ck = period + '_' + r;
+  var _ytAnalytics = YT_ANALYTICS_CACHE[ck];
   var ytViewsTotal = _ytAnalytics ? sum(_ytAnalytics.views) : sum(getYTViews());
-  var igViewTotal  = (IG_MEDIA||[]).reduce(function(a,m){ return a+(m.views||0); }, 0);
-  var periodLabel  = { daily:'최근 7일', weekly:'최근 8주', monthly:'최근 12개월', yearly:'전체' }[period] || '';
+  var cutoff = getPeriodCutoffByRange(period, r);
+  var igFiltered  = (IG_MEDIA||[]).filter(function(m){ return !cutoff || (m.timestamp && new Date(m.timestamp) >= cutoff); });
+  var igViewTotal = igFiltered.reduce(function(a,m){ return a+(m.views||0); }, 0);
+  var periodLabel = getPeriodLabel(period, r);
   var el = document.getElementById('platformChartDesc');
   if (el) el.textContent = periodLabel+' YouTube 조회수 · Instagram 게시물 조회수';
   if (charts.platform) charts.platform.destroy();
@@ -806,73 +951,117 @@ function buildPlatformChart(period) {
 /* ════════════════════════════════════════════════
    YouTube 섹션 차트 빌드
    ════════════════════════════════════════════════ */
-function buildYTCharts(period) {
-  /* 영상 성과 TOP 10 */
-  var _videoAnalytics = YT_VIDEO_ANALYTICS_CACHE[period];
+function buildYTCharts(period, range) {
+  var r = range || DEFAULT_RANGE[period] || 7;
+  var ck = period + '_' + r;
+  var analyticsData   = YT_ANALYTICS_CACHE[ck];
+  var _videoAnalytics = YT_VIDEO_ANALYTICS_CACHE[ck];
+  var periodLabel = getPeriodLabel(period, r);
+
+  /* ── Google 연동 버튼 ── */
+  document.getElementById('ytAuthBtn').style.display = analyticsData ? 'none' : 'inline-block';
+
+  /* ── 영상 성과 TOP 10 ── */
   var ytLabels, ytViews2;
   if (_videoAnalytics && _videoAnalytics.length) {
     var _idToTitle = {};
     if (YT_REAL) YT_REAL.forEach(function(v){ _idToTitle[v.id]=v.title; });
-    ytLabels = _videoAnalytics.map(function(v){ var t=_idToTitle[v.id]||v.id; return t.length>13?t.slice(0,13)+'…':t; });
-    ytViews2 = _videoAnalytics.map(function(v){ return v.views; });
+    ytLabels = _videoAnalytics.slice(0,10).map(function(v){ var t=_idToTitle[v.id]||v.id; return t.length>13?t.slice(0,13)+'…':t; });
+    ytViews2 = _videoAnalytics.slice(0,10).map(function(v){ return v.views; });
   } else {
     ytLabels = getYTLabels();
     ytViews2 = getYTViews();
   }
   var ytColors = YT_VIDEO_COLORS.slice(0, ytLabels.length);
+  var elVD = document.getElementById('ytVideosDesc');
+  if (elVD) elVD.textContent = periodLabel + ' 조회수 상위 영상 순위';
   if (charts.ytVideos) charts.ytVideos.destroy();
+  setNoData('chartYTVideos', isAllZero(ytViews2), '이 기간에 조회된 영상 없음');
   charts.ytVideos = new Chart(document.getElementById('chartYTVideos'), {
     type: 'bar',
     data: { labels: ytLabels, datasets: [{ data:ytViews2, backgroundColor:ytColors.map(function(c){ return c+'cc'; }), borderColor:ytColors, borderWidth:1.5, borderRadius:4, borderSkipped:false }] },
-    options: { responsive:true, maintainAspectRatio:false, indexAxis:'y', plugins:{ legend:{display:false}, tooltip:{callbacks:{label:function(ctx){ return '  '+fmt(ctx.parsed.x)+'회'; }}} }, scales:{ x:{grid:{color:'#f5eaec'}, ticks:{color:'#c090a0', font:{size:11}, callback:function(v){ return fmt(v); }}}, y:{grid:{display:false}, ticks:{color:'#4a2030', font:{size:10}}} } }
+    options: { indexAxis: 'y', responsive:true, maintainAspectRatio:false, plugins:{ legend:{display:false}, tooltip:{callbacks:{label:function(ctx){ return '  '+fmt(ctx.parsed.x)+'회'; }}} }, scales:{ x:{ min:0, grid:{color:'#f5eaec'}, ticks:{color:'#c090a0', font:{size:11}, callback:function(v){ return fmt(v); }}}, y:{grid:{display:false}, ticks:{color:'#4a2030', font:{size:10}}} } }
   });
 
-  /* 채널 성장 트렌드 */
-  var analyticsData = YT_ANALYTICS_CACHE[period];
+  /* ── 기간별 데이터 준비 ── */
   var tLabels, tViews, tLikes, tCmts;
   if (analyticsData) {
-    document.getElementById('ytTrendTitle').textContent = '채널 성장 트렌드';
-    document.getElementById('ytTrendDesc').textContent  = '기간별 조회수 · 좋아요 · 댓글 변화';
-    document.getElementById('ytAuthBtn').style.display  = 'none';
     tLabels = analyticsData.labels;
     tViews  = analyticsData.views;
     tLikes  = analyticsData.likes;
     tCmts   = analyticsData.comments;
+    var elVw = document.getElementById('ytViewsDesc');    if (elVw) elVw.textContent = periodLabel + ' 조회수 변화';
+    var elLk = document.getElementById('ytLikesDesc');    if (elLk) elLk.textContent = periodLabel + ' 좋아요 변화';
+    var elCm = document.getElementById('ytCommentsDesc'); if (elCm) elCm.textContent = periodLabel + ' 댓글 변화';
   } else {
-    document.getElementById('ytTrendTitle').textContent = '채널 성장 트렌드';
-    document.getElementById('ytTrendDesc').textContent  = '전체 영상의 현재 누적 조회수 · 좋아요 · 댓글';
-    document.getElementById('ytAuthBtn').style.display  = 'inline-block';
+    /* Analytics 미연동 시 누적 데이터 대체 표시 */
     var allVideos = (YT_REAL && YT_REAL.length) ? YT_REAL : [];
     tLabels = allVideos.map(function(v){ return v.title.length>14?v.title.slice(0,14)+'…':v.title; });
     tViews  = allVideos.map(function(v){ return v.viewCount; });
     tLikes  = allVideos.map(function(v){ return v.likeCount; });
     tCmts   = allVideos.map(function(v){ return v.commentCount; });
+    var elVw = document.getElementById('ytViewsDesc');    if (elVw) elVw.textContent = '전체 영상 누적 조회수 (Analytics 미연동)';
+    var elLk = document.getElementById('ytLikesDesc');    if (elLk) elLk.textContent = '전체 영상 누적 좋아요 (Analytics 미연동)';
+    var elCm = document.getElementById('ytCommentsDesc'); if (elCm) elCm.textContent = '전체 영상 누적 댓글 (Analytics 미연동)';
   }
-  if (charts.ytTrend) charts.ytTrend.destroy();
-  charts.ytTrend = new Chart(document.getElementById('chartYTTrend'), {
+
+  /* ── 조회수 차트 (선) ── */
+  if (charts.ytViews) charts.ytViews.destroy();
+  setNoData('chartYTViews', isAllZero(tViews), '이 기간에 조회수 데이터 없음');
+  charts.ytViews = new Chart(document.getElementById('chartYTViews'), {
     type: 'line',
-    data: { labels: tLabels, datasets: [
-      { label:'조회수', data:tViews, borderColor:'#e8607a', backgroundColor:'rgba(232,96,122,0.08)', borderWidth:2.5, fill:true, tension:0.4, pointRadius:4, pointBackgroundColor:'#e8607a', pointBorderColor:'#fff', pointBorderWidth:2 },
-      { label:'좋아요', data:tLikes, borderColor:'#f97316', backgroundColor:'rgba(251,146,60,0.08)',  borderWidth:2.5, fill:true, tension:0.4, pointRadius:4, pointBackgroundColor:'#f97316', pointBorderColor:'#fff', pointBorderWidth:2 },
-      { label:'댓글',   data:tCmts,  borderColor:'#a855f7', backgroundColor:'rgba(168,85,247,0.08)', borderWidth:2.5, fill:true, tension:0.4, pointRadius:4, pointBackgroundColor:'#a855f7', pointBorderColor:'#fff', pointBorderWidth:2 },
-    ]},
-    options: { responsive:true, maintainAspectRatio:false, plugins:{ legend:{position:'top', align:'end', labels:{font:{size:11}, usePointStyle:true, pointStyleWidth:8, color:'#5a3040', padding:14}}, tooltip:{callbacks:{label:function(ctx){ return '  '+ctx.dataset.label+': '+fmt(ctx.parsed.y); }}} }, scales:{ x:{grid:{display:false}, ticks:{color:'#4a2030', font:{size:10}, maxRotation:30}}, y:{grid:{color:'#f5eaec'}, ticks:{color:'#c090a0', font:{size:11}, callback:function(v){ return fmt(v); }}} } }
+    data: { labels: tLabels, datasets: [{ label:'조회수', data:tViews, borderColor:'#e8607a', backgroundColor:'rgba(232,96,122,0.08)', borderWidth:2.5, fill:true, tension:0.4, pointRadius:4, pointBackgroundColor:'#e8607a', pointBorderColor:'#fff', pointBorderWidth:2 }] },
+    options: { responsive:true, maintainAspectRatio:false, plugins:{ legend:{display:false}, tooltip:{callbacks:{label:function(ctx){ return '  조회수: '+fmt(ctx.parsed.y); }}} }, scales:{ x:{grid:{display:false}, ticks:{color:'#4a2030', font:{size:10}, maxRotation:30}}, y:yScaleOpt() } }
+  });
+
+  /* ── 좋아요 차트 (막대) ── */
+  if (charts.ytLikes) charts.ytLikes.destroy();
+  setNoData('chartYTLikes', isAllZero(tLikes), '이 기간에 좋아요 데이터 없음');
+  charts.ytLikes = new Chart(document.getElementById('chartYTLikes'), {
+    type: 'bar',
+    data: { labels: tLabels, datasets: [{ label:'좋아요', data:tLikes, backgroundColor:'rgba(249,115,22,0.7)', borderColor:'#f97316', borderWidth:1.5, borderRadius:4, borderSkipped:false }] },
+    options: { responsive:true, maintainAspectRatio:false, plugins:{ legend:{display:false}, tooltip:{callbacks:{label:function(ctx){ return '  좋아요: '+fmt(ctx.parsed.y); }}} }, scales:{ x:{grid:{display:false}, ticks:{color:'#4a2030', font:{size:10}, maxRotation:30}}, y:yScaleOpt() } }
+  });
+
+  /* ── 댓글 차트 (막대) ── */
+  if (charts.ytComments) charts.ytComments.destroy();
+  setNoData('chartYTComments', isAllZero(tCmts), '이 기간에 댓글 데이터 없음');
+  charts.ytComments = new Chart(document.getElementById('chartYTComments'), {
+    type: 'bar',
+    data: { labels: tLabels, datasets: [{ label:'댓글', data:tCmts, backgroundColor:'rgba(168,85,247,0.7)', borderColor:'#a855f7', borderWidth:1.5, borderRadius:4, borderSkipped:false }] },
+    options: { responsive:true, maintainAspectRatio:false, plugins:{ legend:{display:false}, tooltip:{callbacks:{label:function(ctx){ return '  댓글: '+fmt(ctx.parsed.y); }}} }, scales:{ x:{grid:{display:false}, ticks:{color:'#4a2030', font:{size:10}, maxRotation:30}}, y:yScaleOpt() } }
   });
 }
+
+/* ── 기간 + 범위로 레이블 생성 ── */
+function getPeriodLabel(period, range) {
+  if (period === 'daily')   return '최근 ' + range + '일';
+  if (period === 'weekly')  return '최근 ' + range + '주';
+  if (period === 'monthly') return '최근 ' + range + '개월';
+  if (period === 'yearly')  return '최근 ' + range + '년';
+  return '';
+}
+
+/* ── 기간 + 범위로 cutoff 날짜 반환 ── */
+function getPeriodCutoffByRange(period, range) {
+  var d = new Date();
+  var r = range || DEFAULT_RANGE[period] || 7;
+  if      (period === 'daily')   { d.setDate(d.getDate() - r);         return d; }
+  else if (period === 'weekly')  { d.setDate(d.getDate() - r * 7);     return d; }
+  else if (period === 'monthly') { d.setMonth(d.getMonth() - r);       return d; }
+  else if (period === 'yearly')  { d.setFullYear(d.getFullYear() - r); return d; }
+  return null;
+}
+/* 하위 호환 */
+function getPeriodCutoff(period) { return getPeriodCutoffByRange(period, DEFAULT_RANGE[period]); }
 
 /* ════════════════════════════════════════════════
    Instagram 섹션 차트 빌드
    ════════════════════════════════════════════════ */
-function buildIGCharts(period) {
-  var periodLabel = { daily:'최근 7일', weekly:'최근 8주', monthly:'최근 12개월', yearly:'전체' }[period] || '';
-  var cutoff = (function(p){
-    var d = new Date();
-    if (p==='daily')        d.setDate(d.getDate()-7);
-    else if (p==='weekly')  d.setDate(d.getDate()-56);
-    else if (p==='monthly') d.setDate(d.getDate()-365);
-    else return null;
-    return d;
-  })(period);
+function buildIGCharts(period, range) {
+  var r = range || DEFAULT_RANGE[period] || 7;
+  var periodLabel = getPeriodLabel(period, r);
+  var cutoff = getPeriodCutoffByRange(period, r);
   var media = IG_MEDIA ? IG_MEDIA.filter(function(m){ return !cutoff || (m.timestamp && new Date(m.timestamp) >= cutoff); }) : [];
   var mediaCount = media.length ? ' ('+media.length+'개)' : '';
   var el2 = document.getElementById('instaViewsDesc');
@@ -886,17 +1075,19 @@ function buildIGCharts(period) {
     var igLikes  = media.map(function(m){ return m.like_count||0; });
 
     if (charts.instaViews) charts.instaViews.destroy();
+    setNoData('chartInstaViews', isAllZero(igViews), '이 기간에 조회수 데이터 없음');
     charts.instaViews = new Chart(document.getElementById('chartInstaViews'), {
-      type: 'bar', indexAxis: 'y',
-      data: { labels:igLabels, datasets:[{ label:'조회수', data:igViews, backgroundColor:igViews.map(function(_,i){ return 'rgba(221,42,123,'+(0.55+0.04*i)+')'; }), borderColor:'#dd2a7b', borderWidth:1.5, borderRadius:4, borderSkipped:false }] },
-      options: { responsive:true, maintainAspectRatio:false, plugins:{ legend:{display:false}, tooltip:{callbacks:{label:function(ctx){ return '  조회수: '+fmt(ctx.parsed.x)+'회'; }}} }, scales:{ x:{grid:{color:'#f5eaec'}, ticks:{color:'#c090a0', font:{size:11}, callback:function(v){ return fmt(v); }}}, y:{grid:{display:false}, ticks:{color:'#4a2030', font:{size:10}}} } }
+      type: 'bar',
+      data: { labels:igLabels, datasets:[{ label:'조회수', data:igViews, backgroundColor:igViews.map(function(_,i){ return 'rgba(221,42,123,'+Math.min(0.9,0.55+0.04*i)+')'; }), borderColor:'#dd2a7b', borderWidth:1.5, borderRadius:4, borderSkipped:false }] },
+      options: { indexAxis: 'y', responsive:true, maintainAspectRatio:false, plugins:{ legend:{display:false}, tooltip:{callbacks:{label:function(ctx){ return '  조회수: '+fmt(ctx.parsed.x)+'회'; }}} }, scales:{ x:{ min:0, grid:{color:'#f5eaec'}, ticks:{color:'#c090a0', font:{size:11}, callback:function(v){ return fmt(v); }}}, y:{grid:{display:false}, ticks:{color:'#4a2030', font:{size:10}}} } }
     });
 
     if (charts.instaLikes) charts.instaLikes.destroy();
+    setNoData('chartInstaLikes', isAllZero(igLikes), '이 기간에 좋아요 데이터 없음');
     charts.instaLikes = new Chart(document.getElementById('chartInstaLikes'), {
-      type: 'bar', indexAxis: 'y',
-      data: { labels:igLabels, datasets:[{ label:'좋아요', data:igLikes, backgroundColor:igLikes.map(function(_,i){ return 'rgba(129,52,175,'+(0.55+0.04*i)+')'; }), borderColor:'#8134af', borderWidth:1.5, borderRadius:4, borderSkipped:false }] },
-      options: { responsive:true, maintainAspectRatio:false, plugins:{ legend:{display:false}, tooltip:{callbacks:{label:function(ctx){ return '  좋아요: '+fmt(ctx.parsed.x)+'개'; }}} }, scales:{ x:{grid:{color:'#f5eaec'}, ticks:{color:'#c090a0', font:{size:11}, callback:function(v){ return fmt(v); }}}, y:{grid:{display:false}, ticks:{color:'#4a2030', font:{size:10}}} } }
+      type: 'bar',
+      data: { labels:igLabels, datasets:[{ label:'좋아요', data:igLikes, backgroundColor:igLikes.map(function(_,i){ return 'rgba(129,52,175,'+Math.min(0.9,0.55+0.04*i)+')'; }), borderColor:'#8134af', borderWidth:1.5, borderRadius:4, borderSkipped:false }] },
+      options: { indexAxis: 'y', responsive:true, maintainAspectRatio:false, plugins:{ legend:{display:false}, tooltip:{callbacks:{label:function(ctx){ return '  좋아요: '+fmt(ctx.parsed.x)+'개'; }}} }, scales:{ x:{ min:0, grid:{color:'#f5eaec'}, ticks:{color:'#c090a0', font:{size:11}, callback:function(v){ return fmt(v); }}}, y:{grid:{display:false}, ticks:{color:'#4a2030', font:{size:10}}} } }
     });
 
     document.getElementById('instaViewsMsg').style.display  = 'none';
@@ -926,9 +1117,9 @@ function switchTab(tab) {
     tabDirty.main = false;
   } else if (tab === 'sns' && !snsInitialized) {
     /* SNS 탭 첫 진입 시 모든 섹션 빌드 */
-    buildPlatformChart(platformPeriod);
-    buildYTCharts(ytPeriod);
-    buildIGCharts(igPeriod);
+    buildPlatformChart(platformPeriod, platformRange[platformPeriod]);
+    buildYTCharts(ytPeriod, ytRange[ytPeriod]);
+    buildIGCharts(igPeriod, igRange[igPeriod]);
     snsInitialized = true;
   }
 }
@@ -940,23 +1131,26 @@ document.querySelectorAll('.dash-tab-btn').forEach(function(btn){
 /* ════════════════════════════════════════════════
    API 로드 함수들
    ════════════════════════════════════════════════ */
-async function loadAnalytics(period) {
-  var needChannel = !YT_ANALYTICS_CACHE[period];
-  var needVideo   = !YT_VIDEO_ANALYTICS_CACHE[period];
+async function loadAnalytics(period, range) {
+  var r = range || DEFAULT_RANGE[period] || 7;
+  var ck = period + '_' + r;  /* cache key */
+  var needChannel = !YT_ANALYTICS_CACHE[ck];
+  var needVideo   = !YT_VIDEO_ANALYTICS_CACHE[ck];
   if (!needChannel && !needVideo) return;
   try {
+    var qs = '?period=' + period + '&range=' + r;
     var fetches = [];
-    if (needChannel) fetches.push(fetch('/admin/youtube-analytics/?period='+period));
-    if (needVideo)   fetches.push(fetch('/admin/youtube-video-analytics/?period='+period));
+    if (needChannel) fetches.push(fetch('/admin/youtube-analytics/' + qs));
+    if (needVideo)   fetches.push(fetch('/admin/youtube-video-analytics/' + qs));
     var results = await Promise.all(fetches);
     var idx = 0;
     if (needChannel) {
       var d = await results[idx++].json();
-      if (!d.error) YT_ANALYTICS_CACHE[period] = d;
+      if (!d.error) YT_ANALYTICS_CACHE[ck] = d;
     }
     if (needVideo) {
       var d2 = await results[idx++].json();
-      if (!d2.error && d2.videos) YT_VIDEO_ANALYTICS_CACHE[period] = d2.videos;
+      if (!d2.error && d2.videos) YT_VIDEO_ANALYTICS_CACHE[ck] = d2.videos;
     }
   } catch(e) {}
 }
@@ -982,6 +1176,59 @@ async function loadTikTok() {
       }
     }
   } catch(e) {}
+}
+
+async function checkIgToken() {
+  try {
+    var resp = await fetch('/admin/instagram-token/');
+    if (!resp.ok) return;
+    var d = await resp.json();
+    var badge = document.getElementById('igTokenBadge');
+    var btn   = document.getElementById('igTokenRefreshBtn');
+    if (!d.has_token) return;
+    badge.style.display = 'inline-block';
+    btn.style.display   = 'inline-block';
+    if (d.days_left === null || d.days_left === undefined) {
+      badge.textContent = '토큰 상태 확인 중';
+      badge.style.background = '#f3e8ff'; badge.style.color = '#6b21a8';
+    } else if (d.days_left <= 0) {
+      badge.textContent = '토큰 만료됨';
+      badge.style.background = '#fee2e2'; badge.style.color = '#b91c1c';
+    } else if (d.days_left <= 7) {
+      badge.textContent = d.days_left + '일 후 만료';
+      badge.style.background = '#fef3c7'; badge.style.color = '#92400e';
+    } else {
+      badge.textContent = d.days_left + '일 남음';
+      badge.style.background = '#dcfce7'; badge.style.color = '#166534';
+    }
+  } catch(e) {}
+}
+
+async function refreshIgToken() {
+  var btn = document.getElementById('igTokenRefreshBtn');
+  btn.disabled = true; btn.textContent = '갱신 중...';
+  try {
+    var resp = await fetch('/admin/instagram-token/', { method: 'POST', headers: {'X-CSRFToken': getCookie('csrftoken')} });
+    var d = await resp.json();
+    if (d.refreshed) {
+      var badge = document.getElementById('igTokenBadge');
+      badge.textContent = d.days_left + '일 남음';
+      badge.style.background = '#dcfce7'; badge.style.color = '#166534';
+      btn.textContent = '갱신 완료';
+      setTimeout(function(){ btn.disabled = false; btn.textContent = '토큰 갱신'; }, 3000);
+    } else {
+      alert('갱신 실패: ' + (d.error || '알 수 없는 오류'));
+      btn.disabled = false; btn.textContent = '토큰 갱신';
+    }
+  } catch(e) {
+    alert('갱신 요청 중 오류가 발생했습니다.');
+    btn.disabled = false; btn.textContent = '토큰 갱신';
+  }
+}
+
+function getCookie(name) {
+  var v = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
+  return v ? v[2] : '';
 }
 
 async function loadInstagram() {
@@ -1026,7 +1273,7 @@ async function loadDashboard() {
     }
   } catch(e) { console.error('Dashboard load failed:', e); }
 
-  await Promise.all([loadAnalytics('daily'), loadInstagram(), loadTikTok(), loadInstagramMedia()]);
+  await Promise.all([loadAnalytics('daily', 7), loadInstagram(), loadTikTok(), loadInstagramMedia(), checkIgToken()]);
 
   updateYTCard();
   buildMainCharts('daily');
@@ -1036,8 +1283,17 @@ async function loadDashboard() {
   if (params.get('yt_auth') === 'error')   alert('❌ YouTube Analytics 연동 실패. 다시 시도해주세요.');
 }
 
-/* ── 섹션별 기간 버튼 이벤트 ── */
+/* ── 범위 그룹 전환 헬퍼 ── */
+function switchRangeGroup(bar, period) {
+  bar.querySelectorAll('.range-group').forEach(function(g){
+    g.style.display = g.dataset.for === period ? 'inline-flex' : 'none';
+  });
+}
+
+/* ── 섹션별 기간 + 범위 버튼 이벤트 ── */
 document.querySelectorAll('.section-period-bar').forEach(function(bar) {
+
+  /* 기간 버튼 */
   bar.querySelectorAll('.period-btn').forEach(function(btn) {
     btn.addEventListener('click', async function() {
       bar.querySelectorAll('.period-btn').forEach(function(b){ b.classList.remove('active'); });
@@ -1045,21 +1301,60 @@ document.querySelectorAll('.section-period-bar').forEach(function(bar) {
       var period  = this.dataset.period;
       var section = bar.dataset.section;
 
+      /* 범위 그룹 전환 + 기본 범위 버튼 active 초기화 */
+      switchRangeGroup(bar, period);
+      var defR = DEFAULT_RANGE[period];
+      bar.querySelectorAll('.range-group[data-for="'+period+'"] .range-btn').forEach(function(rb){
+        rb.classList.toggle('active', parseInt(rb.dataset.range) === defR);
+      });
+
       if (section === 'main') {
         mainPeriod = period;
         if (activeTab === 'main') buildMainCharts(mainPeriod);
         else tabDirty.main = true;
       } else if (section === 'platform') {
         platformPeriod = period;
-        await loadAnalytics(platformPeriod);
-        buildPlatformChart(platformPeriod);
+        platformRange[period] = defR;
+        await loadAnalytics(platformPeriod, defR);
+        buildPlatformChart(platformPeriod, defR);
       } else if (section === 'yt') {
         ytPeriod = period;
-        await loadAnalytics(ytPeriod);
-        buildYTCharts(ytPeriod);
+        ytRange[period] = defR;
+        await loadAnalytics(ytPeriod, defR);
+        buildYTCharts(ytPeriod, defR);
       } else if (section === 'ig') {
         igPeriod = period;
-        buildIGCharts(igPeriod);
+        igRange[period] = defR;
+        buildIGCharts(igPeriod, defR);
+      }
+    });
+  });
+
+  /* 범위 버튼 */
+  bar.querySelectorAll('.range-btn').forEach(function(btn) {
+    btn.addEventListener('click', async function() {
+      var group     = this.closest('.range-group');
+      var forPeriod = group.dataset.for;
+      group.querySelectorAll('.range-btn').forEach(function(rb){ rb.classList.remove('active'); });
+      this.classList.add('active');
+      var range   = parseInt(this.dataset.range);
+      var section = bar.dataset.section;
+
+      if (section === 'platform') {
+        platformRange[forPeriod] = range;
+        if (platformPeriod === forPeriod) {
+          await loadAnalytics(platformPeriod, range);
+          buildPlatformChart(platformPeriod, range);
+        }
+      } else if (section === 'yt') {
+        ytRange[forPeriod] = range;
+        if (ytPeriod === forPeriod) {
+          await loadAnalytics(ytPeriod, range);
+          buildYTCharts(ytPeriod, range);
+        }
+      } else if (section === 'ig') {
+        igRange[forPeriod] = range;
+        if (igPeriod === forPeriod) buildIGCharts(igPeriod, range);
       }
     });
   });


### PR DESCRIPTION
- 동영상은 video_views 직접 취득, 이미지는 impressions→reach 순 폴백
- indexAxis:'y' 위치 오류 수정 (config 최상단 → options 내부)
- _instagram_token() 헬퍼로 캐시 기반 토큰 자동 갱신 (만료 7일 전 트리거)
- instagram_token_api 뷰 추가 (GET: 만료일 조회, POST: 수동 갱신)
- 어드민 대시보드 Instagram 헤더에 토큰 만료 배지 + 갱신 버튼 표시