### PR TITLE
Feat: About Hari 섹션·페이지 및 인증 모달 UX/폰트 개선

### DIFF
--- a/backend/templates/frontend/abouthari.html
+++ b/backend/templates/frontend/abouthari.html
@@ -12,6 +12,9 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_20-10@1.0/LoveType.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2210@1.0/SejongGeulgot.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-dynamic-subset.min.css">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Jua&display=swap" rel="stylesheet">
 <script src="{% static 'js/theme.js' %}"></script>
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box;}
@@ -21,6 +24,7 @@
   --f-cute:'LoveType',sans-serif;
   --f-thin:'SejongGeulgot',sans-serif;
   --f-neo:'NeoDunggeunmo',sans-serif;
+  --f-round:'Jua',sans-serif;
   --bg:#ffffff;--ink:#2a2420;--acc:#ff7b8a;--acc2:#ffd166;--acc3:#06d6a0;
   --dim:#9e9490;--bdr:rgba(255,123,138,0.12);--bdr2:rgba(255,123,138,0.22);
 }
@@ -38,7 +42,7 @@ body{background:var(--bg);color:var(--ink);font-family:Pretendard,'Apple SD Goth
 /* NAV */
 .pf-nav{position:fixed;top:0;left:0;right:0;z-index:100;height:64px;display:flex;align-items:center;justify-content:space-between;padding:0 2.5rem;border-bottom:.5px solid var(--bdr);background:rgba(255,255,255,0.95);backdrop-filter:blur(16px);}
 .pf-nav-logo img{height:44px;width:auto;mix-blend-mode:multiply;}
-.pf-nav-back{font-family:'DM Mono',monospace;font-size:.6rem;letter-spacing:.18em;text-transform:uppercase;color:var(--dim);text-decoration:none;display:flex;align-items:center;gap:.5rem;transition:color .2s;}
+.pf-nav-back{font-family:var(--f-round);font-size:.78rem;letter-spacing:.02em;color:var(--dim);text-decoration:none;display:flex;align-items:center;gap:.5rem;transition:color .2s;}
 .pf-nav-back:hover{color:var(--acc);}
 .pf-nav-back svg{transition:transform .2s;}
 .pf-nav-back:hover svg{transform:translateX(-3px);}
@@ -73,12 +77,15 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
 .pf-info-panel{overflow-y:auto;padding:3.5rem 3rem;border-left:.5px solid var(--bdr);}
 
 /* 이름 헤더 */
-.pf-tag{font-family:'DM Mono',monospace;font-size:.54rem;letter-spacing:.26em;text-transform:uppercase;color:var(--dim);margin-bottom:1.4rem;}
+.pf-tag{font-family:var(--f-round);font-size:.78rem;letter-spacing:.04em;color:var(--acc);margin-bottom:1.4rem;}
 
 
 /* Name block */
-.pf-name{font-family:var(--f-playful);font-size:clamp(2.8rem,5vw,5rem);line-height:1.1;letter-spacing:-0.02em;color:var(--ink);margin-bottom:.35rem;}
-.pf-name-en{font-family:'DM Mono',monospace;font-size:.66rem;letter-spacing:.28em;text-transform:uppercase;color:var(--dim);margin-bottom:1.8rem;}
+.pf-name{
+  font-family:'Jua',sans-serif; font-size:clamp(3rem,5vw,5.2rem); line-height:1.15; letter-spacing:.02em;
+  color:var(--ink); margin-bottom:.35rem;
+}
+.pf-name-en{font-family:var(--f-round);font-size:.82rem;letter-spacing:.05em;color:var(--dim);margin-bottom:1.8rem;}
 
 /* Bio */
 .pf-bio{font-size:.94rem;line-height:1.7;letter-spacing:-0.01em;color:var(--ink);max-width:480px;margin-bottom:2.5rem;padding-bottom:2.5rem;border-bottom:.5px solid var(--bdr);}
@@ -87,28 +94,28 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
 .pf-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:0;border:.5px solid var(--bdr);margin-bottom:2.5rem;}
 .pf-stat{padding:1.2rem 1rem;border-right:.5px solid var(--bdr);text-align:center;}
 .pf-stat:last-child{border-right:none;}
-.pf-stat-num{font-family:'Bebas Neue',sans-serif;font-size:2rem;color:var(--ink);display:block;line-height:1;}
-.pf-stat-lbl{font-family:'DM Mono',monospace;font-size:.72rem;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);display:block;margin-top:.3rem;}
+.pf-stat-num{font-family:var(--f-round);font-size:2rem;color:var(--ink);display:block;line-height:1.1;}
+.pf-stat-lbl{font-family:var(--f-round);font-size:.76rem;letter-spacing:.02em;color:var(--dim);display:block;margin-top:.3rem;}
 
 /* Keywords */
 .pf-keywords{display:flex;flex-wrap:wrap;gap:.5rem;margin-bottom:2.5rem;padding-bottom:2.5rem;border-bottom:.5px solid var(--bdr);}
-.pf-kw{font-family:'DM Mono',monospace;font-size:.82rem;letter-spacing:.1em;padding:5px 14px;border:.5px solid var(--bdr2);color:var(--dim);transition:all .2s;}
-.pf-kw:hover{border-color:var(--acc);color:var(--acc);}
+.pf-kw{font-family:var(--f-round);font-size:.82rem;letter-spacing:.01em;padding:6px 16px;border:.5px solid var(--bdr2);border-radius:20px;color:var(--dim);transition:all .2s;}
+.pf-kw:hover{border-color:var(--acc);color:var(--acc);background:rgba(255,123,138,0.06);}
 
 /* SNS */
-.pf-sns-title{font-family:'DM Mono',monospace;font-size:.78rem;letter-spacing:.2em;text-transform:uppercase;color:var(--dim);margin-bottom:1.2rem;}
+.pf-sns-title{font-family:var(--f-round);font-size:.88rem;letter-spacing:.02em;color:var(--dim);margin-bottom:1.2rem;}
 .pf-sns-grid{display:flex;flex-direction:column;gap:.5rem;margin-bottom:2.5rem;padding-bottom:2.5rem;border-bottom:.5px solid var(--bdr);}
-.pf-sns-item{display:flex;align-items:center;justify-content:space-between;padding:.85rem 1rem;border:.5px solid var(--bdr);text-decoration:none;transition:all .2s;}
+.pf-sns-item{display:flex;align-items:center;justify-content:space-between;padding:.85rem 1.1rem;border:.5px solid var(--bdr);border-radius:14px;text-decoration:none;transition:all .2s;}
 .pf-sns-item:hover{border-color:var(--acc);background:rgba(255,123,138,0.04);}
 .pf-sns-left{display:flex;align-items:center;gap:.9rem;}
-.pf-sns-icon{width:32px;height:32px;border-radius:8px;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
-.pf-sns-name{font-family:var(--f-playful);font-size:.95rem;color:var(--ink);}
-.pf-sns-handle{font-family:'DM Mono',monospace;font-size:.78rem;letter-spacing:.1em;color:var(--dim);}
-.pf-sns-arr{font-family:'DM Mono',monospace;font-size:.65rem;color:var(--dim);transition:transform .2s;}
+.pf-sns-icon{width:34px;height:34px;border-radius:10px;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+.pf-sns-name{font-family:var(--f-round);font-size:.95rem;color:var(--ink);}
+.pf-sns-handle{font-family:var(--f-round);font-size:.78rem;letter-spacing:.01em;color:var(--dim);}
+.pf-sns-arr{font-family:var(--f-round);font-size:.75rem;color:var(--dim);transition:transform .2s;}
 .pf-sns-item:hover .pf-sns-arr{transform:translateX(4px);color:var(--acc);}
 
 /* Gallery preview */
-.pf-gallery-title{font-family:'DM Mono',monospace;font-size:.54rem;letter-spacing:.2em;text-transform:uppercase;color:var(--dim);margin-bottom:1.2rem;display:flex;justify-content:space-between;align-items:center;}
+.pf-gallery-title{font-family:var(--f-round);font-size:.82rem;letter-spacing:.02em;color:var(--dim);margin-bottom:1.2rem;display:flex;justify-content:space-between;align-items:center;}
 .pf-gallery-link{color:var(--acc);text-decoration:none;border-bottom:.5px solid var(--acc);padding-bottom:1px;transition:color .2s;}
 .pf-gallery-link:hover{color:var(--ink);}
 .pf-gallery-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:.5rem;}
@@ -118,19 +125,19 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
 
 /* QUOTE */
 .pf-quote{margin-bottom:2rem;padding:1.4rem 1.6rem;background:rgba(255,123,138,0.04);border-left:3px solid var(--acc);border-radius:0 10px 10px 0;}
-.pf-quote-text{font-family:var(--f-playful);font-size:1.05rem;color:var(--ink);line-height:1.8;letter-spacing:-0.01em;margin-bottom:.4rem;}
-.pf-quote-from{font-family:'DM Mono',monospace;font-size:.72rem;letter-spacing:.16em;text-transform:uppercase;color:var(--dim);}
+.pf-quote-text{font-family:var(--f-round);font-size:1.05rem;color:var(--ink);line-height:1.8;letter-spacing:.01em;margin-bottom:.4rem;}
+.pf-quote-from{font-family:var(--f-round);font-size:.8rem;letter-spacing:.02em;color:var(--dim);}
 
 /* LIKES */
 .pf-likes{display:grid;grid-template-columns:1fr 1fr;gap:.5rem;margin-bottom:2rem;padding-bottom:2rem;border-bottom:.5px solid var(--bdr);}
 .pf-like-item{display:flex;align-items:center;gap:.7rem;padding:.75rem .9rem;border:.5px solid var(--bdr);border-radius:10px;transition:border-color .2s,background .2s;}
 .pf-like-item:hover{border-color:var(--acc);background:rgba(255,123,138,0.04);}
 .pf-like-icon{font-size:1.2rem;flex-shrink:0;}
-.pf-like-text{font-size:.82rem;color:var(--ink);font-weight:400;letter-spacing:-0.01em;line-height:1.5;}
+.pf-like-text{font-family:var(--f-round);font-size:.84rem;color:var(--ink);letter-spacing:.01em;line-height:1.5;}
 
 /* CTA */
 .pf-cta{margin-top:2.5rem;padding-top:2.5rem;border-top:.5px solid var(--bdr);display:flex;gap:1rem;}
-.pf-btn{font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:.82rem;font-weight:500;letter-spacing:-0.01em;padding:.85rem 1.8rem;text-decoration:none;transition:all .2s;display:inline-flex;align-items:center;gap:.5rem;border-radius:8px;}
+.pf-btn{font-family:var(--f-round);font-size:.88rem;letter-spacing:.01em;padding:.85rem 1.8rem;text-decoration:none;transition:all .2s;display:inline-flex;align-items:center;gap:.5rem;border-radius:24px;}
 .pf-btn-primary{background:var(--acc);color:#fff;border:.5px solid var(--acc);}
 .pf-btn-primary:hover{background:#ff4c6c;border-color:#ff4c6c;}
 .pf-btn-secondary{background:transparent;color:var(--ink);border:.5px solid var(--bdr2);}
@@ -260,7 +267,7 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
             <svg viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.8" width="16" height="16" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="#fff" stroke="none"/></svg>
           </div>
           <div>
-            <div class="pf-sns-name">Instagram</div>
+            <div class="pf-sns-name">전달 하리</div>
             <div class="pf-sns-handle">@jeondal__hari</div>
           </div>
         </div>
@@ -272,7 +279,7 @@ html[data-theme="dark"] #theme-toggle.on::after{background:var(--ink);}
             <svg viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.8" width="16" height="16" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="#fff" stroke="none"/></svg>
           </div>
           <div>
-            <div class="pf-sns-name" style="display:flex;align-items:center;gap:.5rem;">Instagram <span style="font-size:.6rem;letter-spacing:.06em;background:rgba(255,123,138,0.15);color:var(--acc);padding:1px 6px;border-radius:3px;font-weight:600;">기록</span></div>
+            <div class="pf-sns-name" style="display:flex;align-items:center;gap:.5rem;">기록 하리</div>
             <div class="pf-sns-handle">@girok_hari</div>
           </div>
         </div>

--- a/backend/templates/frontend/chat.html
+++ b/backend/templates/frontend/chat.html
@@ -806,9 +806,18 @@ html[data-theme="dark"] .date-divider-text {
 .message-group {
   display: flex;
   gap: 12px;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
   align-items: flex-end;
   animation: msgFadeIn 0.3s ease-out;
+}
+
+/* 연속 말풍선: 같은 사람이 이어질 때 간격 좁힘 */
+.message-group.continued {
+  margin-bottom: 3px;
+}
+.message-group.continued + .message-group.continued,
+.message-group.continued + .message-group {
+  margin-top: 0;
 }
 
 @keyframes msgFadeIn {
@@ -886,11 +895,11 @@ html[data-theme="dark"] .date-divider-text {
 
 /* 말풍선 공통 스타일 */
 .msg-bubble {
-  padding: 12px 18px;
+  padding: 10px 16px;
   border-radius: 20px;
-  font-size: 1rem;
+  font-size: 0.97rem;
   font-family: 'Pretendard Variable', Pretendard, 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
-  line-height: 1.6;
+  line-height: 1.65;
   letter-spacing: -0.02em;
   position: relative;
   box-shadow: var(--bubble-shadow);
@@ -915,6 +924,26 @@ html[data-theme="dark"] .date-divider-text {
   color: white;
   border: none;
   font-weight: 400;
+}
+
+/* 연속 말풍선 모서리 그룹 (카카오톡 스타일) */
+/* 하리(other) 연속 */
+.message-group.other.bubble-mid .msg-bubble,
+.message-group.other.bubble-last .msg-bubble {
+  border-top-left-radius: 6px;
+}
+.message-group.other.bubble-first .msg-bubble,
+.message-group.other.bubble-mid .msg-bubble {
+  border-bottom-left-radius: 6px;
+}
+/* 내(me) 연속 */
+.message-group.me.bubble-mid .msg-bubble,
+.message-group.me.bubble-last .msg-bubble {
+  border-top-right-radius: 6px;
+}
+.message-group.me.bubble-first .msg-bubble,
+.message-group.me.bubble-mid .msg-bubble {
+  border-bottom-right-radius: 6px;
 }
 
 
@@ -1575,7 +1604,8 @@ function sanitizeHari(text) {
 
 function splitMessage(text) {
   if (!text) return [];
-  return text.split(/\n+/).filter(s => s.trim().length > 0);
+  // 빈 줄(\n\n 이상)에서만 말풍선 분리, 단순 줄바꿈은 같은 말풍선 내 <br>로 처리
+  return text.split(/\n{2,}/).map(s => s.trim()).filter(s => s.length > 0);
 }
 
 function renderSingleHariBubble(text, options = {}) {
@@ -1584,14 +1614,29 @@ function renderSingleHariBubble(text, options = {}) {
   const now = timestamp ? new Date(timestamp) : new Date();
   const timeStr = formatTime(now);
   const dateKey = checkAndAddDateDivider(now);
-  
+
   const msgId = 'msg-' + (++messageCounter);
   chatHistory.push({ id: msgId, date: dateKey, time: timeStr, sender: 'hari', text: text });
 
+  // 연속 말풍선 클래스 결정
+  let groupClass = '';
+  if (!isFirst && !isLast) groupClass = 'bubble-mid continued';
+  else if (!isFirst && isLast) groupClass = 'bubble-last continued';
+  else if (isFirst && !isLast) groupClass = 'bubble-first continued';
+
+  // 직전 말풍선의 시간 숨기기 (연속일 때)
+  if (!isFirst) {
+    const prev = messages.querySelector('.message-group.other:last-child');
+    if (prev) {
+      const prevMeta = prev.querySelector('.msg-meta');
+      if (prevMeta) prevMeta.style.display = 'none';
+    }
+  }
+
   const html = `
-    <div class="message-group other ${animate ? '' : 'no-animate'}" id="${msgId}">
-      <div class="msg-profile" style="${isFirst ? '' : 'visibility: hidden; height: 0; margin-top: -8px;'}">
-        <img src="${window.hariCurrentProfile || '{% static 'images/hari_image19.webp' %}'}" style="width: 100%; height: 100%; border-radius: inherit; object-fit: cover;">
+    <div class="message-group other ${groupClass} ${animate ? '' : 'no-animate'}" id="${msgId}">
+      <div class="msg-profile" style="${isFirst ? '' : 'visibility:hidden;width:44px;flex-shrink:0;'}">
+        <img src="${window.hariCurrentProfile || '{% static 'images/hari_image19.webp' %}'}" style="width:100%;height:100%;border-radius:inherit;object-fit:cover;">
       </div>
       <div class="msg-content">
         ${isFirst ? '<div class="msg-name">하리</div>' : ''}
@@ -1625,6 +1670,7 @@ function appendHariMessage(text, isHistory = false, timestamp = null) {
     renderSingleHariBubble(segments[0], { isFirst: true, isLast: segments.length === 1, animate: true });
 
     if (segments.length > 1) {
+      // slice(1) 이후 인덱스 기준: 마지막은 i === segments.length - 2
       bubbleQueue = segments.slice(1).map((seg, i) => ({ text: seg, isLast: i === segments.length - 2 }));
       scheduleNextBubble();
     } else {

--- a/backend/templates/frontend/homepage.html
+++ b/backend/templates/frontend/homepage.html
@@ -12,6 +12,9 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_20-10@1.0/LoveType.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2210@1.0/SejongGeulgot.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-dynamic-subset.min.css">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Jua&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
 <script src="{% static 'js/theme.js' %}"></script>
 <style>
@@ -23,6 +26,7 @@
   --f-cute:    'LoveType', sans-serif;
   --f-thin:    'SejongGeulgot', sans-serif;
   --f-neo:     'NeoDunggeunmo', sans-serif;
+  --f-round:   'Jua', sans-serif;
   /* ── HARI COLOR SYSTEM v3 ──────────────────
      컨셉: Bright & Cheerful — 밝고 털털하고 귀여운 하리
      베이스: 따뜻한 순백 (눈에 편함)
@@ -421,31 +425,31 @@ body { background:var(--bg); color:var(--ink); font-family:Pretendard,'Apple SD 
   margin-bottom:2rem;
 }
 .auth-tab {
-  font-family:'DM Mono',monospace; font-size:.62rem;
-  letter-spacing:.16em; text-transform:uppercase;
+  font-family:'Jua',sans-serif; font-size:.82rem;
+  letter-spacing:.02em;
   padding:.7rem 0; margin-right:1.8rem;
   background:transparent; border:none; border-bottom:1.5px solid transparent;
   color:var(--dim); cursor:pointer;
   transition:color .2s, border-color .2s;
   margin-bottom:-0.5px;
 }
-.auth-tab.on { color:var(--ink); border-bottom-color:var(--ink); }
+.auth-tab.on { color:var(--ink); border-bottom-color:var(--acc); }
 
 /* panels */
 .auth-panel { display:none; flex-direction:column; gap:.9rem; }
 .auth-panel.on { display:flex; }
 
 .auth-title {
-  font-family:'Bebas Neue',sans-serif;
-  font-size:2.3rem; letter-spacing:.04em;
+  font-family:'WagleWagle',sans-serif;
+  font-size:2.1rem; letter-spacing:.01em;
   background:linear-gradient(135deg, var(--acc) 0%, #ff5c73 100%);
   -webkit-background-clip:text; -webkit-text-fill-color:transparent;
   background-clip:text;
-  line-height:1; margin-bottom:.5rem; font-weight:700;
+  line-height:1.15; margin-bottom:.5rem;
 }
 .auth-sub {
-  font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;
-  font-size:1.05rem; font-weight:400; line-height:1.8; color:var(--dim);
+  font-family:'Jua',sans-serif;
+  font-size:.95rem; line-height:1.8; color:var(--dim);
   margin-bottom:.8rem;
 }
 
@@ -474,8 +478,8 @@ body { background:var(--bg); color:var(--ink); font-family:Pretendard,'Apple SD 
 /* divider */
 .auth-divider {
   display:flex; align-items:center; gap:.8rem;
-  font-family:'DM Mono',monospace; font-size:.54rem;
-  letter-spacing:.14em; text-transform:uppercase; color:var(--dim);
+  font-family:'Jua',sans-serif; font-size:.78rem;
+  letter-spacing:.02em; color:var(--dim);
 }
 .auth-divider::before, .auth-divider::after {
   content:''; flex:1; height:0.5px; background:var(--bdr);
@@ -494,8 +498,8 @@ body { background:var(--bg); color:var(--ink); font-family:Pretendard,'Apple SD 
 .auth-inp-row { display:grid; grid-template-columns:1fr 1fr; gap:.6rem; }
 
 .auth-label {
-  font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif; font-size:.78rem;
-  font-weight:600; letter-spacing:.02em;
+  font-family:'Jua',sans-serif; font-size:.82rem;
+  letter-spacing:.01em;
   color:var(--dim); margin-bottom:.4rem; display:block;
 }
 .auth-field { display:flex; flex-direction:column; }
@@ -503,15 +507,30 @@ body { background:var(--bg); color:var(--ink); font-family:Pretendard,'Apple SD 
 /* checkbox */
 .auth-check {
   display:flex; align-items:flex-start; gap:.6rem;
-  font-size:.75rem; color:var(--dim); cursor:pointer; line-height:1.6;
+  font-family:'Jua',sans-serif; font-size:.78rem;
+  color:var(--dim); cursor:pointer; line-height:1.7;
 }
-.auth-check input { accent-color:var(--acc); margin-top:3px; flex-shrink:0; }
+.auth-check input { accent-color:var(--acc); margin-top:4px; flex-shrink:0; }
 .auth-check a { color:var(--acc); text-decoration:none; border-bottom:0.5px solid var(--acc); }
+.auth-required-badge {
+  display:inline-block; font-family:'Jua',sans-serif; font-size:.65rem;
+  background:rgba(255,123,138,0.12); color:var(--acc);
+  border:0.5px solid rgba(255,123,138,0.3); border-radius:20px;
+  padding:1px 7px; margin-left:3px; vertical-align:middle;
+  line-height:1.6;
+}
+.auth-optional-badge {
+  display:inline-block; font-family:'Jua',sans-serif; font-size:.65rem;
+  background:rgba(158,148,144,0.1); color:var(--dim);
+  border:0.5px solid rgba(158,148,144,0.25); border-radius:20px;
+  padding:1px 7px; margin-left:3px; vertical-align:middle;
+  line-height:1.6;
+}
 
 /* forgot */
 .auth-forgot {
-  font-family:'DM Mono',monospace; font-size:.56rem;
-  letter-spacing:.1em; color:var(--dim); text-decoration:none;
+  font-family:'Jua',sans-serif; font-size:.76rem;
+  letter-spacing:.01em; color:var(--dim); text-decoration:none;
   border-bottom:0.5px solid var(--bdr2);
   align-self:flex-end; cursor:pointer;
   background:transparent; border-left:none; border-top:none; border-right:none;
@@ -522,11 +541,11 @@ body { background:var(--bg); color:var(--ink); font-family:Pretendard,'Apple SD 
 /* submit */
 .auth-submit {
   background:linear-gradient(135deg, #ff7b8a 0%, #ff5c73 100%); border:none; color:#fff;
-  font-family:'DM Mono',monospace; font-size:.85rem;
-  letter-spacing:.14em; text-transform:uppercase;
-  padding:1rem; cursor:pointer; width:100%; font-weight:700;
+  font-family:'Jua',sans-serif; font-size:1rem;
+  letter-spacing:.02em;
+  padding:1rem; cursor:pointer; width:100%;
   transition:all .3s;
-  border-radius:10px;
+  border-radius:24px;
   box-shadow:0 4px 15px rgba(255,123,138,0.4);
 }
 .auth-submit:hover {
@@ -536,12 +555,13 @@ body { background:var(--bg); color:var(--ink); font-family:Pretendard,'Apple SD 
 .auth-submit:active { transform:translateY(0); }
 
 .auth-switch {
-  font-size:.9rem; color:var(--dim); text-align:center; line-height:1.8;
+  font-family:'Jua',sans-serif; font-size:.82rem;
+  color:var(--dim); text-align:center; line-height:1.8;
 }
 .auth-switch button {
   background:transparent; border:none; border-bottom:0.5px solid var(--acc);
-  color:var(--acc); font-family:Pretendard,'Apple SD Gothic Neo','Noto Sans KR',sans-serif; font-size:.9rem;
-  cursor:pointer; padding:0; transition:color .2s; font-weight:500;
+  color:var(--acc); font-family:'Jua',sans-serif; font-size:.82rem;
+  cursor:pointer; padding:0; transition:color .2s;
 }
 .auth-switch button:hover { color:var(--ink); }
 
@@ -676,16 +696,19 @@ section { width:100%; border-bottom:0.5px solid var(--bdr); }
 
 .profile-info-content { display:flex; flex-direction:column; gap:2.5rem; }
 .profile-name-row { display:flex; align-items:baseline; justify-content:space-between; border-bottom:0.5px solid var(--bdr); padding-bottom:1.5rem; }
-.profile-char-name { font-family:var(--f-playful); font-size:4rem; color:var(--ink); line-height:1.1; letter-spacing:-0.02em; }
-.profile-more-link { font-family:var(--f-pixel); font-size:.85rem; color:var(--acc); text-decoration:none; border-bottom:1px solid var(--acc); padding-bottom:2px; }
+.profile-char-name {
+  font-family:'Jua',sans-serif; font-size:4.4rem; line-height:1.1; letter-spacing:.02em; color:var(--ink);
+}
+.profile-more-link { font-family:var(--f-round); font-size:.88rem; color:var(--acc); text-decoration:none; border-bottom:1.5px solid var(--acc); padding-bottom:2px; letter-spacing:.01em; }
 
 .profile-sns-row { display:flex; gap:1.5rem; flex-wrap:wrap; }
 .profile-sns-row a { display:flex; align-items:center; gap:.8rem; text-decoration:none; transition:transform .2s; }
 .profile-sns-row a:hover { transform:translateY(-3px); }
 .sns-icon-wrap { width:36px; height:36px; border-radius:10px; display:flex; align-items:center; justify-content:center; }
-.sns-icon-name { font-family:var(--f-pixel); font-size:.75rem; color:var(--dim); text-transform:uppercase; letter-spacing:.05em; }
+.sns-icon-name { font-family:var(--f-round); font-size:.78rem; color:var(--dim); letter-spacing:.01em; }
 
-.profile-desc-box { font-family:'Noto Sans KR',Pretendard,'Apple SD Gothic Neo',sans-serif; font-size:1.05rem; line-height:1.8; letter-spacing:-0.01em; font-weight:400; color:var(--ink); background:rgba(255,123,138,0.03); padding:2rem; border-left:3px solid var(--acc); }
+.profile-desc-box { font-family:'Jua',sans-serif; font-size:.95rem; line-height:1.9; letter-spacing:.01em; color:var(--ink); background:rgba(255,123,138,0.03); padding:2rem; border-left:3px solid var(--acc); }
+#s2 .sec-title { font-family:'Jua',sans-serif; font-size:clamp(1.8rem,4vw,3rem); letter-spacing:.02em; }
 
 @media(max-width:1024px){
   .profile-main-container { flex-direction:column; gap:3rem; }
@@ -1631,53 +1654,28 @@ function debounceEmailCheck(email){
   const statusEl=document.getElementById('email-status');
   const messageEl=document.getElementById('email-message');
   if(!email){
-    statusEl.textContent='';
-    messageEl.textContent='';
+    if(statusEl) statusEl.textContent='';
+    if(messageEl) messageEl.textContent='';
     window.emailValidated=false;
     return;
   }
-  statusEl.textContent='🔄';
-  messageEl.textContent='검증 중...';
   emailCheckTimeout=setTimeout(()=>{
     checkEmailValidity(email);
-  },500);
+  },300);
 }
 function checkEmailValidity(email){
   const statusEl=document.getElementById('email-status');
   const messageEl=document.getElementById('email-message');
   const emailRegex=/^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if(!emailRegex.test(email)){
-    statusEl.textContent='❌';
-    messageEl.textContent='유효하지 않은 이메일 형식입니다.';
-    messageEl.style.color='#ff7b8a';
+    if(statusEl) statusEl.textContent='❌';
+    if(messageEl){ messageEl.textContent='올바른 이메일 형식이 아닙니다.'; messageEl.style.color='#ff7b8a'; }
     window.emailValidated=false;
     return;
   }
-  fetch('/api/auth/verify-email/',{
-    method:'POST',
-    headers:{'Content-Type':'application/json','X-CSRFToken':getCookie('csrftoken')},
-    body:JSON.stringify({email:email})
-  }).then(r=>{
-    if(!r.ok) return r.json().then(d=>{throw d;});
-    return r.json();
-  }).then(data=>{
-    if(data.valid||data.available){
-      statusEl.textContent='✅';
-      messageEl.textContent='사용 가능한 이메일입니다.';
-      messageEl.style.color='#06d6a0';
-      window.emailValidated=true;
-    }else{
-      statusEl.textContent='❌';
-      messageEl.textContent=data.message||'이미 가입된 이메일입니다.';
-      messageEl.style.color='#ff7b8a';
-      window.emailValidated=false;
-    }
-  }).catch(err=>{
-    statusEl.textContent='⚠️';
-    messageEl.textContent='검증 서버 오류입니다.';
-    messageEl.style.color='#ffd166';
-    window.emailValidated=false;
-  });
+  if(statusEl) statusEl.textContent='✅';
+  if(messageEl){ messageEl.textContent='사용 가능한 이메일 형식입니다.'; messageEl.style.color='#06d6a0'; }
+  window.emailValidated=true;
 }
 // 비밀번호 검증
 function debouncePasswordCheck(password){

--- a/backend/templates/frontend/includes/homepage/_nav_auth.html
+++ b/backend/templates/frontend/includes/homepage/_nav_auth.html
@@ -479,11 +479,11 @@
 
       <label class="auth-check" for="signup-terms">
         <input type="checkbox" id="signup-terms" name="signup-terms" required>
-        <button type="button" onclick="openTermsModal('terms')" style="background:none; border:none; border-bottom:0.5px solid var(--acc); color:var(--acc); cursor:pointer; padding:0; font-family:inherit; font-size:inherit;">이용약관</button> 및 <button type="button" onclick="openTermsModal('privacy')" style="background:none; border:none; border-bottom:0.5px solid var(--acc); color:var(--acc); cursor:pointer; padding:0; font-family:inherit; font-size:inherit;">개인정보처리방침</button>에 동의합니다.
+        <span><button type="button" onclick="openTermsModal('terms')" style="background:none; border:none; border-bottom:0.5px solid var(--acc); color:var(--acc); cursor:pointer; padding:0; font-family:inherit; font-size:inherit;">이용약관</button> 및 <button type="button" onclick="openTermsModal('privacy')" style="background:none; border:none; border-bottom:0.5px solid var(--acc); color:var(--acc); cursor:pointer; padding:0; font-family:inherit; font-size:inherit;">개인정보처리방침</button>에 동의합니다. <span class="auth-required-badge">필수</span></span>
       </label>
       <label class="auth-check" for="signup-news">
         <input type="checkbox" id="signup-news" name="signup-news">
-        하리의 소식 및 멤버십 알림 수신에 동의합니다. (선택)
+        <span>하리의 소식 및 멤버십 알림 수신에 동의합니다. <span class="auth-optional-badge">선택</span></span>
       </label>
 
       <button class="auth-submit" onclick="doSignup()">가입하기 →</button>

--- a/backend/templates/frontend/includes/homepage/_s2_abouthari.html
+++ b/backend/templates/frontend/includes/homepage/_s2_abouthari.html
@@ -26,14 +26,14 @@
             <div class="sns-icon-wrap" style="background:linear-gradient(45deg,#f09433,#e6683c,#dc2743,#cc2366,#bc1888);">
               <svg viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="#fff" stroke="none"/></svg>
             </div>
-            <span class="sns-icon-name">Instagram</span>
+            <span class="sns-icon-name">전달 하리</span>
           </a>
           <!-- Instagram (기록 부계정) -->
           <a href="https://www.instagram.com/girok_hari/" target="_blank" rel="noopener">
             <div class="sns-icon-wrap" style="background:linear-gradient(45deg,#f09433,#e6683c,#dc2743,#cc2366,#bc1888);opacity:0.72;">
               <svg viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="#fff" stroke="none"/></svg>
             </div>
-            <span class="sns-icon-name" style="font-size:0.62rem;">기록 인스타</span>
+            <span class="sns-icon-name" style="font-size:0.62rem;">기록 하리</span>
           </a>
           <!-- YouTube -->
           <a href="https://www.youtube.com/@Hari-o5m2r" target="_blank" rel="noopener">

--- a/backend/templates/frontend/includes/homepage/_s8_footer.html
+++ b/backend/templates/frontend/includes/homepage/_s8_footer.html
@@ -31,7 +31,7 @@
   <div class="ft-sns-area">
     <div class="ft-sns-lbl">Follow Hari</div>
     <ul class="sns-list">
-      <li class="sns-item"><a class="sns-link" href="https://www.instagram.com/jeondal__hari/" target="_blank" rel="noopener"><span class="sns-ko">인스타그램</span><span class="sns-en">Instagram</span><span class="sns-arr">↗</span></a></li>
+      <li class="sns-item"><a class="sns-link" href="https://www.instagram.com/jeondal__hari/" target="_blank" rel="noopener"><span class="sns-ko">전달 하리</span><span class="sns-en">Instagram</span><span class="sns-arr">↗</span></a></li>
       <li class="sns-item"><a class="sns-link" href="https://www.youtube.com/@Hari-o5m2r" target="_blank" rel="noopener"><span class="sns-ko">유튜브</span><span class="sns-en">YouTube</span><span class="sns-arr">↗</span></a></li>
       <li class="sns-item"><a class="sns-link" href="https://www.tiktok.com/@coding__hari" target="_blank" rel="noopener"><span class="sns-ko">틱톡</span><span class="sns-en">TikTok</span><span class="sns-arr">↗</span></a></li>
     </ul>
@@ -95,14 +95,14 @@ FOOTER_V1_END -->
 <div class="ft-sns-area">
   <div class="ft-sns-lbl">Follow Hari</div>
   <ul class="sns-list">
-    <li class="sns-item"><a class="sns-link" href="https://www.instagram.com/jeondal__hari/" target="_blank" rel="noopener"><span class="sns-ko">인스타그램</span><span class="sns-en">Instagram</span><span class="sns-arr">↗</span></a></li>
-    <li class="sns-item sns-item--sub"><a class="sns-link sns-link--sub" href="https://www.instagram.com/girok_hari/" target="_blank" rel="noopener"><span class="sns-ko">인스타그램 <span class="sns-badge">기록</span></span><span class="sns-en">Daily Archive</span><span class="sns-arr">↗</span></a></li>
+    <li class="sns-item"><a class="sns-link" href="https://www.instagram.com/jeondal__hari/" target="_blank" rel="noopener"><span class="sns-ko">전달 하리</span><span class="sns-en">Instagram</span><span class="sns-arr">↗</span></a></li>
+    <li class="sns-item sns-item--sub"><a class="sns-link sns-link--sub" href="https://www.instagram.com/girok_hari/" target="_blank" rel="noopener"><span class="sns-ko">기록 하리</span><span class="sns-en">Daily Archive</span><span class="sns-arr">↗</span></a></li>
     <li class="sns-item"><a class="sns-link" href="https://www.youtube.com/@Hari-o5m2r" target="_blank" rel="noopener"><span class="sns-ko">유튜브</span><span class="sns-en">YouTube</span><span class="sns-arr">↗</span></a></li>
     <li class="sns-item"><a class="sns-link" href="https://www.tiktok.com/@coding__hari" target="_blank" rel="noopener"><span class="sns-ko">틱톡</span><span class="sns-en">TikTok</span><span class="sns-arr">↗</span></a></li>
     <li class="sns-item sns-item--linktree"><a class="sns-link sns-link--linktree" href="https://linktr.ee/chatting_hari" target="_blank" rel="noopener"><span class="sns-ko">모든 링크 모음</span><span class="sns-en">Linktree</span><span class="sns-arr">↗</span></a></li>
   </ul>
   <style>
-  .sns-item--sub { padding-left: 0.8rem; }
+  .sns-item--sub { padding-left: 0; }
   .sns-link--sub { opacity: 0.75; font-size: 0.92em; }
   .sns-link--sub:hover { opacity: 1; }
   .sns-badge {


### PR DESCRIPTION
- abouthari 섹션·페이지 전체 폰트 Jua(둥근 한글)로 교체, DM Mono 제거
- '하리' 이름 폰트 Jua 적용, 키워드 태그·SNS 카드 모서리 둥글게
- 회원가입 모달 폰트 Jua·WagleWagle로 통일, 이메일 검증 서버 호출 제거(형식만 확인)
- 이용약관 필수·선택 뱃지 추가, 제출 버튼 border-radius 확대
- 채팅 말풍선 연속 간격 축소 및 모서리 그룹 처리(카카오톡 스타일)
- SNS 링크명 변경: Instagram → 전달 하리, 기록 인스타 → 기록 하리
- 푸터 기록 하리 좌측 들여쓰기 제거