### PR TITLE
수정: 채팅 말풍선 줄바꿈을 자연스럽게 개선

### DIFF
--- a/backend/templates/frontend/chat.html
+++ b/backend/templates/frontend/chat.html
@@ -859,7 +859,7 @@ html[data-theme="dark"] .date-divider-text {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  max-width: 65%;
+  max-width: 72%;
 }
 
 .message-group.me .msg-content {
@@ -903,10 +903,12 @@ html[data-theme="dark"] .date-divider-text {
   letter-spacing: -0.02em;
   position: relative;
   box-shadow: var(--bubble-shadow);
+  white-space: pre-wrap;
   word-wrap: break-word;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  max-width: 75%;
+  overflow-wrap: anywhere;
+  word-break: keep-all;
+  line-break: strict;
+  max-width: 100%;
   min-width: 0;
 }
 


### PR DESCRIPTION
하리 채팅 말풍선이 글자 단위로 어색하게 끊지 않도록 조정
문장 흐름을 최대한 유지하고, 긴 문장은 자연스럽게 다음 줄로 내려가게 개선