### PR TITLE
Fix: 채팅 검색 탭 밑줄 전환 버그 수정 및 UI 개선

### DIFF
--- a/backend/templates/frontend/chat.html
+++ b/backend/templates/frontend/chat.html
@@ -98,11 +98,11 @@ html[data-theme="dark"] .input-button {
 }
 
 html[data-theme="dark"] .search-input-wrapper {
-  background: #251d1a !important;
+  background: #ffffff !important;
 }
 
 html[data-theme="dark"] .search-input-wrapper:focus-within {
-  background: #3d3530 !important;
+  background: #ffffff !important;
   border-color: var(--hari-pink) !important;
 }
 
@@ -476,7 +476,7 @@ html, body {
   display: flex;
   align-items: center;
   gap: 10px;
-  background: var(--bg-main);
+  background: #ffffff;
   border: 0.5px solid var(--border);
   border-radius: 12px;
   padding: 10px 16px;
@@ -1858,7 +1858,17 @@ function performSearch() {
 function searchByDate() {
   const from = document.getElementById('dateFrom').value;
   const to = document.getElementById('dateTo').value;
-  if (!from || !to) { alert('날짜를 모두 선택해줘!'); return; }
+  if (!from || !to) {
+    document.getElementById('searchResults').innerHTML = `
+      <div style="margin-top:8px; padding:16px 18px; background:rgba(255,123,138,0.08); border:1px solid rgba(255,123,138,0.3); border-radius:14px; display:flex; align-items:center; gap:12px;">
+        <span style="font-size:22px; flex-shrink:0;">📅</span>
+        <div>
+          <div style="font-size:13px; font-weight:600; color:var(--hari-pink); margin-bottom:2px;">날짜를 모두 선택해줘!</div>
+          <div style="font-size:11px; color:var(--text-dim); line-height:1.5;">From · To 날짜를 모두 지정해야<br>검색할 수 있어요.</div>
+        </div>
+      </div>`;
+    return;
+  }
   const results = chatHistory.filter(msg => msg.date >= from && msg.date <= to);
   displaySearchResults(results);
 }

--- a/backend/templates/frontend/includes/chat/_search.html
+++ b/backend/templates/frontend/includes/chat/_search.html
@@ -15,8 +15,8 @@
 
   <!-- 검색 탭 (키워드/날짜) -->
   <div class="search-tabs" style="display: flex; gap: 8px; border-bottom: 1px solid var(--border); padding-bottom: 8px;">
-    <button class="search-tab active" onclick="switchSearchTab(event, 'keyword')" style="background: none; border: none; padding: 6px 12px; font-size: 13px; font-weight: 500; color: var(--hari-pink); cursor: pointer; border-bottom: 2px solid var(--hari-pink); flex: 1;">키워드</button>
-    <button class="search-tab" onclick="switchSearchTab(event, 'date')" style="background: none; border: none; padding: 6px 12px; font-size: 13px; font-weight: 500; color: var(--text-dim); cursor: pointer; flex: 1;">날짜</button>
+    <button class="search-tab active" onclick="switchSearchTab(event, 'keyword')" style="flex: 1;">키워드</button>
+    <button class="search-tab" onclick="switchSearchTab(event, 'date')" style="flex: 1;">날짜</button>
   </div>
 
   <!-- 날짜 필터 (Hidden by default) -->


### PR DESCRIPTION
- 검색 탭 인라인 스타일 제거 → CSS 클래스 기반으로 교체해 날짜 탭 분홍 밑줄 정상 작동
- 날짜 미선택 검색 시 브라우저 alert 제거 → 검색창 내 인라인 안내 카드로 교체
- 메시지 검색 입력창 배경 라이트/다크 모드 모두 흰색으로 고정